### PR TITLE
Prepare for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,22 @@ GOLANGCI_LINT_CONFIG = .golangci.yml
 IMAGE_REGISTRY ?= quay.io
 IMAGE_REPOSITORY ?= deployment-validation-operator
 IMAGE_NAME ?= ${OPERATOR_NAME}
+OPERATOR_IMAGE_URI_TEST=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):test
+QUAY_USER ?=
+QUAY_TOKEN ?=
 
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
+
+.PHONY: docker-test
+docker-test:
+	${CONTAINER_ENGINE} build . -f $(OPERATOR_DOCKERFILE).test -t $(OPERATOR_IMAGE_URI_TEST)
+	${CONTAINER_ENGINE} run -t $(OPERATOR_IMAGE_URI_TEST)
+
+.PHONY: docker-login-and-push
+docker-login-and-push: docker-build
+	@CONFIG_DIR=`mktemp -d`; \
+	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io; \
+	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" push $(OPERATOR_IMAGE_URI); \
+	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" push $(OPERATOR_IMAGE_URI_LATEST)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,10 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
+
+RUN mkdir -p /workdir
+COPY . /workdir
+WORKDIR /workdir
+RUN make
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/deployment-validation-operator \
@@ -5,7 +12,7 @@ ENV OPERATOR=/usr/local/bin/deployment-validation-operator \
     USER_NAME=deployment-validation-operator
 
 # install operator binary
-COPY build/_output/bin/deployment-validation-operator ${OPERATOR}
+COPY --from=builder /workdir/build/_output/bin/deployment-validation-operator ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/build/Dockerfile.test
+++ b/build/Dockerfile.test
@@ -1,0 +1,8 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
+
+RUN mkdir -p /workdir
+COPY . /workdir
+WORKDIR /workdir
+
+ENTRYPOINT  ["make"]
+CMD ["go-check", "test"]


### PR DESCRIPTION
* Image is built through a multi-stage build to avoid depending on the
  go interpreter from the environment
* Create a make target to test using a Docker to avoid depending on the
  go interpreter from the environment
* Added a make target to login and push

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>