### PR TITLE
Add new target in Makefile for docker login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,11 @@ docker-test:
 	${CONTAINER_ENGINE} run -t $(OPERATOR_IMAGE_URI_TEST)
 
 .PHONY: docker-login-and-push
-docker-login-and-push: docker-build
-	@CONFIG_DIR=`mktemp -d`; \
-	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io; \
+docker-login-and-push: docker-login docker-build
 	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" push $(OPERATOR_IMAGE_URI); \
 	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" push $(OPERATOR_IMAGE_URI_LATEST)
+
+.PHONY: docker-login
+docker-login:
+	@CONFIG_DIR=`mktemp -d`; \
+	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io; \


### PR DESCRIPTION
This is needed because docker needs to be logged into before generating
the image in order for the proper username to be included in the docker
image name