### PR TITLE
Removed additional docker login make target and set user in build_deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,7 @@ docker-test:
 
 .PHONY: docker-login-and-push
 docker-login-and-push: docker-login docker-build
-	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" push $(OPERATOR_IMAGE_URI); \
-	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" push $(OPERATOR_IMAGE_URI_LATEST)
-
-.PHONY: docker-login
-docker-login:
 	@CONFIG_DIR=`mktemp -d`; \
 	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io; \
+	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" push $(OPERATOR_IMAGE_URI); \
+	${CONTAINER_ENGINE} --config="$${CONFIG_DIR}" push $(OPERATOR_IMAGE_URI_LATEST)

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-make docker-login-and-push
+USER=$QUAY_USER make docker-login-and-push


### PR DESCRIPTION
When creating an image, the org used when generating the image
name is defined by the USER env which is usually the username
running the command.  This isn't always the desired namespace for
things like CI/CD