### PR TITLE
Make REPLACE_VERSION optional when generating the CSV for the bundle.

### DIFF
--- a/deploy/bundle/Makefile
+++ b/deploy/bundle/Makefile
@@ -24,6 +24,9 @@ manifest:
 	TEMPLATE=`mktemp` ; \
 	./generate-csv-template.py > $${TEMPLATE} ; \
 	oc process --local -o yaml --raw=true IMAGE=$(OPERATOR_IMAGE) IMAGE_TAG=$(OPERATOR_IMAGE_TAG) VERSION=$(VERSION) REPLACE_VERSION=$(REPLACE_VERSION) -f $${TEMPLATE} > $(CSV)
+	@if [ "${REPLACE_VERSION}" == "" ]; then \
+	  sed -i.bak "/replaces/d" $(CSV); \
+	fi
 
 bundle: manifest
 	docker build -t ${IMAGE}:${IMAGE_TAG} .

--- a/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
+++ b/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
@@ -72,4 +72,3 @@ parameters:
   required: true
 - name: REPLACE_VERSION
   value: ""
-  required: true


### PR DESCRIPTION
The first time a bundle is built there will be no version to replace,
so need to make it optional and remove references to it in the CSV.