### PR TITLE
Remove Operator Metrics Server

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/app-sre/deployment-validation-operator/version"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
@@ -39,9 +38,8 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
-	operatorMetricsPort int32 = 8686
+	metricsHost       = "0.0.0.0"
+	metricsPort int32 = 8383
 )
 var log = logf.Log.WithName("DeploymentValidation")
 
@@ -159,10 +157,6 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 		}
 	}
 
-	if err := serveCRMetrics(cfg, operatorNs); err != nil {
-		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
-	}
-
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []v1.ServicePort{
 		{
@@ -170,12 +164,6 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 			Name:       metrics.OperatorPortName,
 			Protocol:   v1.ProtocolTCP,
 			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort},
-		},
-		{
-			Port:       operatorMetricsPort,
-			Name:       metrics.CRPortName,
-			Protocol:   v1.ProtocolTCP,
-			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort},
 		},
 	}
 
@@ -202,32 +190,4 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 				err.Error())
 		}
 	}
-}
-
-// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
-// It serves those metrics on "http://metricsHost:operatorMetricsPort".
-func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
-	// The function below returns a list of filtered operator/CR specific GVKs.
-	// For more control, override the GVK list below
-	// with your own custom logic. Note that if you are adding third party API schemas,
-	// probably you will need to customize this implementation to avoid permissions issues.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
-	if err != nil {
-		return err
-	}
-
-	// The metrics will be generated from the namespaces which are returned here.
-	// NOTE that passing nil or an empty list of namespaces in GenerateAndServeCRMetrics will
-	// result in an error.
-	ns, err := kubemetrics.GetNamespacesForMetrics(operatorNs)
-	if err != nil {
-		return err
-	}
-
-	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
-	if err != nil {
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
It is not serving any metric, so unless it is used for something I don't understand I would remove it and just have one single metrics endpoint.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>