### PR TITLE
Fixes to catalog/bundle generation

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -20,7 +20,8 @@ CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/d
 
 # Generate version and tag information from inputs
 COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
-CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
+# Standard/App-SRE sha length is 7 instead of 8
+CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
 OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
 
 IMG?=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):v$(OPERATOR_VERSION)

--- a/build_catalog.sh
+++ b/build_catalog.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
+set -e
+
+function log ()
+{
+  echo "######## $1 ########"
+}
 
 count=0
-for var in BUNDLE_IMAGE_NAME \
-           CATALOG_IMAGE_NAME \
+for var in BUNDLE_IMAGE \
+           CATALOG_IMAGE \
            QUAY_USER \
            QUAY_TOKEN
 do
   if [ ! "${!var}" ]; then
-    echo "$var is not set"
+    log "$var is not set"
     count=$((count + 1))
   fi
 done
@@ -27,20 +33,21 @@ docker_cmd="docker --config=$docker_conf"
 $docker_cmd login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
 # Find the CSV version from the previous bundle
-echo "pulling laster bundle image"
-$docker_cmd pull $BUNDLE_IMAGE_NAME:latest && exists=1 || exists=0
+log "Pulling lastest bundle image $BUNDLE_IMAGE"
+$docker_cmd pull $BUNDLE_IMAGE:latest && exists=1 || exists=0
 
 if [ $exists -eq 1 ]; then
-  echo "extracting previous version from bundle image"
-  docker create --name="tmp_$$" $BUNDLE_IMAGE_NAME:latest sh
+  log "Extracting previous version from bundle image"
+  docker create --name="tmp_$$" $BUNDLE_IMAGE:latest sh
   tmp_dir=$(mktemp -d -t sa-XXXXXXXXXX)
   pushd $tmp_dir
     docker export tmp_$$ | tar -xf -
     prev_version=`find . -name *.clusterserviceversion.* | xargs cat - | python3 -c 'import sys,yaml; print(yaml.safe_load(sys.stdin.read())["metadata"]["name"])'`
-    echo $prev_version
     if [[ "$prev_version" == "" ]]; then
+      log "Unable to find previous bundle version"
       exit 1
     fi
+    log "Found previous bundle version $prev_version"
   popd
   rm -rf $tmp_dir
   docker rm tmp_$$
@@ -48,19 +55,22 @@ fi
 
 # Build/push the new bundle
 pushd deploy/bundle
-  echo "creating the bundle"
+  log "Creating bundle $BUNDLE_IMAGE:$current_commit"
   if [[ $prev_version != "" ]]; then
     export REPLACE_VERSION=$prev_version
   fi
-  export IMAGE=$BUNDLE_IMAGE_NAME
-  export IMAGE_TAG=$current_commit
+  export BUNDLE_IMAGE_TAG=$current_commit
+  export OPERATOR_IMAGE_TAG=$current_commit
   export VERSION=$version
   make bundle
+  docker tag $BUNDLE_IMAGE:$current_commit $BUNDLE_IMAGE:latest
 
-  echo "pushing the bundle to repository"
-  docker tag $BUNDLE_IMAGE_NAME:$current_commit $BUNDLE_IMAGE_NAME:latest
-  $docker_cmd push $BUNDLE_IMAGE_NAME:$current_commit
-  $docker_cmd push $BUNDLE_IMAGE_NAME:latest
+  log "Pushing the bundle $BUNDLE_IMAGE:$current_commit to repository"
+  $docker_cmd push $BUNDLE_IMAGE:$current_commit
+  # Do not push the latest tag here.  If there is a problem creating the catalog then
+  # pushing the latest tag here will mean subsequent runs will be extracting a bundle
+  # version that isn't referenced in the catalog.  This will result in all future
+  # catalog creation failing to be created.
 popd
 
 # Download opm build
@@ -68,16 +78,28 @@ curl -L https://github.com/operator-framework/operator-registry/releases/downloa
 chmod u+x ./opm
 
 # Create/push a new catalog via opm
-echo "pulling existing latest catalog"
-$docker_cmd pull $CATALOG_IMAGE_NAME:latest && exists=1 || exists=0
+log "Pulling existing latest catalog $CATALOG_IMAGE"
+$docker_cmd pull $CATALOG_IMAGE:latest && exists=1 || exists=0
 if [ $exists -eq 1 ]; then
-  from_arg="--from-index $CATALOG_IMAGE_NAME:latest"
+  from_arg="--from-index $CATALOG_IMAGE:latest"
 fi
 
-echo "creating new catalog"
-./opm index add --bundles $BUNDLE_IMAGE_NAME:$current_commit $from_arg --tag $CATALOG_IMAGE_NAME:$current_commit --build-tool docker
+if [[ "$from_arg" == "" ]]; then
+  log "Creating new catalog $CATALOG_IMAGE"
+else
+  log "Updating existing catalog $CATALOG_IMAGE"
+fi
 
-echo "pushing catalog to repository"
-docker tag $CATALOG_IMAGE_NAME:$current_commit $CATALOG_IMAGE_NAME:latest
-$docker_cmd push $CATALOG_IMAGE_NAME:$current_commit
-$docker_cmd push $CATALOG_IMAGE_NAME:latest
+./opm index add --bundles $BUNDLE_IMAGE:$current_commit $from_arg --tag $CATALOG_IMAGE:$current_commit --build-tool docker
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+docker tag $CATALOG_IMAGE:$current_commit $CATALOG_IMAGE:latest
+
+log "Pushing catalog $CATALOG_IMAGE:$current_commit to repository"
+$docker_cmd push $CATALOG_IMAGE:$current_commit
+
+# Only put the latest tags once everything else has succeeded
+log "Pushing latest tags for $BUNDLE_IMAGE and $CATALOG_IMAGE"
+$docker_cmd push $CATALOG_IMAGE:latest
+$docker_cmd push $BUNDLE_IMAGE:latest

--- a/build_catalog.sh
+++ b/build_catalog.sh
@@ -33,7 +33,7 @@ docker_cmd="docker --config=$docker_conf"
 $docker_cmd login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
 # Find the CSV version from the previous bundle
-log "Pulling lastest bundle image $BUNDLE_IMAGE"
+log "Pulling latest bundle image $BUNDLE_IMAGE"
 $docker_cmd pull $BUNDLE_IMAGE:latest && exists=1 || exists=0
 
 if [ $exists -eq 1 ]; then
@@ -60,7 +60,7 @@ pushd deploy/bundle
     export REPLACE_VERSION=$prev_version
   fi
   export BUNDLE_IMAGE_TAG=$current_commit
-  export OPERATOR_IMAGE_TAG=$current_commit
+  export OPERATOR_IMAGE_TAG=$version
   export VERSION=$version
   make bundle
   docker tag $BUNDLE_IMAGE:$current_commit $BUNDLE_IMAGE:latest

--- a/deploy/bundle/Makefile
+++ b/deploy/bundle/Makefile
@@ -1,9 +1,9 @@
-ifndef IMAGE
-IMAGE=quay.io/app-sre/deployment-validation-operator-bundle
+ifndef BUNDLE_IMAGE
+BUNDLE_IMAGE=quay.io/app-sre/deployment-validation-operator-bundle
 endif
 
-ifndef IMAGE_TAG
-IMAGE_TAG=latest
+ifndef BUNDLE_IMAGE_TAG
+BUNDLE_IMAGE_TAG=latest
 endif
 
 ifndef OPERATOR_IMAGE
@@ -30,10 +30,10 @@ manifest:
 	fi
 
 bundle: manifest
-	docker build -t ${IMAGE}:${IMAGE_TAG} .
+	docker build -t ${BUNDLE_IMAGE}:${BUNDLE_IMAGE_TAG} .
 
 push: bundle
-	docker push ${IMAGE}:${IMAGE_TAG}
+	docker push ${BUNDLE_IMAGE}:${BUNDLE_IMAGE_TAG}
 
 clean:
 	rm -rf ${MANIFEST_DIR}

--- a/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
+++ b/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ objects:
     maturity: alpha
     provider:
       name: Red Hat
-    replaces: deployment-validation-operator.v${REPLACE_VERSION}
+    replaces: ${REPLACE_VERSION}
     selector:
       matchLabels:
         alm-owner-dvo: deployment-validation-operator


### PR DESCRIPTION
The bundle was being generated with the incorrect operator image
tag which causes a failure in catalog generation.  Since latest
tag is used that tag can not be pushed unless bundle and catalog
generation succeed.  Also changed the bundle/catalog env names to
be more consistent with other names for images