### PR TITLE
Proposal single channel

### DIFF
--- a/deploy/bundle/generate-csv-template.py
+++ b/deploy/bundle/generate-csv-template.py
@@ -5,6 +5,13 @@ import os
 import sys
 import yaml
 import pathlib
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-r", "--replaces", help="Replaces version", type=str)
+parser.add_argument('-s','--skip', action='append',
+        help='Skips version (can be specified multiple times)')
+args = parser.parse_args()
 
 root = pathlib.Path(__file__).parent.absolute() / '../..'
 manifest_dir = root / 'deploy/openshift'
@@ -46,6 +53,15 @@ with open(manifest_dir / 'operator.yaml', 'r') as stream:
 
 csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = \
     '${IMAGE}:${IMAGE_TAG}'
+
+if args.replaces:
+    csv['spec']['replaces'] = f'deployment-validation-operator.v{args.replaces}'
+
+if args.skip:
+    csv['spec']['skips'] = [
+        f'deployment-validation-operator.v{version}' for version in
+        sorted(args.skip, key=lambda v: int(v.split('.')[2].split('-')[0]))
+    ]
 
 now = datetime.datetime.now()
 csv['metadata']['annotations']['createdAt'] = \

--- a/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
+++ b/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
@@ -56,7 +56,6 @@ objects:
     maturity: alpha
     provider:
       name: Red Hat
-    replaces: deployment-validation-operator.v${REPLACE_VERSION}
     selector:
       matchLabels:
         alm-owner-dvo: deployment-validation-operator
@@ -70,5 +69,3 @@ parameters:
 - name: VERSION
   value: ""
   required: true
-- name: REPLACE_VERSION
-  value: ""

--- a/deploy/openshift/deployment-validation-operator-olm.yaml
+++ b/deploy/openshift/deployment-validation-operator-olm.yaml
@@ -10,7 +10,7 @@ objects:
     name: deployment-validation-operator-catalog
   spec:
     sourceType: grpc
-    image: ${IMAGE}:${CHANNEL}-${IMAGE_TAG}
+    image: ${IMAGE}:${IMAGE_TAG}
     displayName: Deployment Validation Operator
     publisher: AppSRE Team
 - apiVersion: operators.coreos.com/v1alpha1
@@ -38,8 +38,6 @@ parameters:
   displayName: deployment-validation-operator catalog version
   description: the version of the deployment-validation-operator catalog to deploy
   required: true
-- name: CHANNEL
-  value: staging
 - name: NAMESPACE
   value: ""
   displayName: namespace to deploy into

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 make docker-login-and-push
-BRANCH_CHANNEL=staging make channel-catalog
-BRANCH_CHANNEL=production REMOVE_UNDEPLOYED=true make channel-catalog
+make channel-catalog


### PR DESCRIPTION
Yesterday we met with the OLM team and the introduced us the `semver` approach. It seems good at first sight for us, however there are two things that we can't fix with the `semver` approach:

- The appeal of using `semver` is that you don't need to store state, you only need to fetch the latest index image and add a new bundle to it. However, we still need state in order to be able to rebuild the index image in a disaster event in the container registry.
- If we use `semver` we can't easily skip a faulty version. Let's say we find a bundle to be faulty. In this scenario we want to ensure that the next time we build a bundle it jumps over the fault version. The `skips` parameter is ignored in the `semver` mode. Maybe we could use `skipRange` (which is respected at runtime in `semver` mode), but we haven't explored this.

Given these two reasons we propose to continue using the `replaces` approach, with two changes:

1. We stop pruning versions, because the ultimate goal is to **run the same payload in stage and in prod**. The consequence of this is that we only need one channel now, therefore only one branch (this is reflected in the PR, see commit https://github.com/jmelis/deployment-validation-operator/commit/6138d2cb1c5a1e3d4513dfa6d7494d2cd3a05a2f).
1. Provide a process to skip a faulty bundle. This is the process:
    - Go to the saas bundle repo and append `SKIP` at the end of the `bundle_versions_file`. Next time the CI job is run, once the code is fixed, it will skip that version and make the new bundle replace the last healthy one.
    - In the staging cluster manually delete the csv, catalogsource and subscription objects. That way when the fixed catalog lands it will install the latest version.

The whole point of this proposal is that we are using the same payload for staging and production, which means we are testing the upgrade path. Note that it also simplifies the build process a bit because we are removing the bundle pruning logic.