### PR TITLE
Initialize skip versions if it doesn't exist

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -334,7 +334,7 @@ function main() {
                                                    "$opm_local_executable" \
                                                    "$image_builder" \
                                                    "$prev_good_operator_version" \
-                                                   "${skip_versions[*]}")
+                                                   "${skip_versions[*]:-}")
 
     log "Pushing bundle image $bundle_image_current_commit"
     $engine_cmd push "$bundle_image_current_commit"


### PR DESCRIPTION
Fixing line 337: skip_versions[*]: unbound variable

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>