### PR TITLE
Don't check for CPU limits

### DIFF
--- a/pkg/testutils/templates/Deployment.yaml.tpl
+++ b/pkg/testutils/templates/Deployment.yaml.tpl
@@ -115,7 +115,6 @@ spec:
         resources:
           {{- if .ResourceLimits }}
           limits:
-            cpu: "1"
             memory: 1Gi
           {{- end }}
           {{- if .ResourceRequests }}

--- a/pkg/testutils/templates/ReplicaSet.yaml.tpl
+++ b/pkg/testutils/templates/ReplicaSet.yaml.tpl
@@ -118,7 +118,6 @@ spec:
         resources:
           {{- if .ResourceLimits }}
           limits:
-            cpu: "1"
             memory: 1Gi
           {{- end }}
           {{- if .ResourceRequests }}

--- a/pkg/validations/requests_limits.go
+++ b/pkg/validations/requests_limits.go
@@ -60,7 +60,7 @@ func (r *RequestLimitValidation) Validate(request reconcile.Request, obj interfa
 			Interface().(core_v1.PodTemplateSpec)
 		for _, c := range podTemplateSpec.Spec.Containers {
 			if c.Resources.Requests.Memory().IsZero() || c.Resources.Requests.Cpu().IsZero() ||
-				c.Resources.Limits.Memory().IsZero() || c.Resources.Limits.Cpu().IsZero() {
+				c.Resources.Limits.Memory().IsZero() {
 				logger.Info("does not have requests or limits set")
 				r.metric.With(promLabels).Set(1)
 				return


### PR DESCRIPTION
There are [volumes](https://www.google.com/search?q=don%27t+use+cpu+limits) written on this, but setting CPU limits is generally a bad idea for production workloads. It can drastically slow applications down, because of the way CFS shares are sliced and calculated.

Requests are great for both CPU and memory as they aid in scheduling. Memory limits can serve as a safety mechanism for systems without swap, and are immediately actionable by the OOMKiller. But CPU limits in the CFS scheduler are hard to set, and they can slow your application down by restricting CPU time, even if you aren't anywhere close to the limit set.

This PR removes limits from this metric.

cc @jewzaam @mwoodson @jharrington22 @robotmaxtron FYI