### PR TITLE
Override `build-push` properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ docker-test:
 
 # We are early adopters of the OPM build/push process. Remove this
 # override once boilerplate uses that path by default.
-build-push: opm-build-push
+build-push: opm-build-push ;


### PR DESCRIPTION
TIL if you do this:

```make
foo:
    do_a_thing

foo: bar
```

...the "override" doesn't actually stop the original `foo` from running. So the above will actually run `bar` and then `do_a_thing`.

You have to give the override substance. So:

```make
foo:
    do_a_thing

foo: bar
    do_a_different_thing
```

...will run `bar` and then `do_a_different_thing`.

In our case we actually want to *replace* `foo` with `bar` so we have to give the override "no-op" substance, which looks like this:

```make
foo:
    do_a_thing

foo: bar ;
```

(note the semicolon)
This will *just* run `bar` when `make foo` is invoked.