### PR TITLE
Delete metrics for validations not in the report from kube-linter

### DIFF
--- a/pkg/validations/base.go
+++ b/pkg/validations/base.go
@@ -43,7 +43,7 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 
 	// Clear labels from past run to ensure only results from this run
 	// are reflected in the metrics
-	engine.ClearMetrics(promLabels)
+	engine.ClearMetrics(result.Reports, promLabels)
 
 	for _, report := range result.Reports {
 		logger := log.WithValues(


### PR DESCRIPTION
The problem to solve is two-fold:
1. Original implementation was setting 0 to clear metrics, generating a LOT of metrics for passed validations
2. Original implementation was resetting all labels for a metric before processing the results.  This would cause metric flapping for failed validations

This change attempts to handle the above intelligently.  When clearing the metrics, it will delete the labels from a metric if that metric is not in the list of failed checks returned by kube-linter.  Then the processing of the results continues as before, setting a metric for each failed validation.