### PR TITLE
Disable incompatible checks

### DIFF
--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -1,6 +1,7 @@
 package validations
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
@@ -162,14 +163,12 @@ func getAllBuiltInKubeLinterChecks() ([]string, error) {
 	}
 	registry := checkregistry.New()
 	if err := builtinchecks.LoadInto(registry); err != nil {
-		log.Error(err, "failed to load built-in validations")
-		return nil, err
+		return nil, fmt.Errorf("failed to load built-in validations: %s", err.Error())
 	}
 
 	enabledChecks, err := configresolver.GetEnabledChecksAndValidate(&ve.config, registry)
 	if err != nil {
-		log.Error(err, "error finding enabled validations")
-		return nil, err
+		return nil, fmt.Errorf("error finding enabled validations: %s", err.Error())
 	}
 
 	return enabledChecks, nil

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -138,13 +138,16 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 
 	enabledChecks := e.EnabledChecks()
 	if len(enabledChecks) <= 10 {
-		t.Errorf("Expected more than 10 checks to be enabled, but got '%v' from '%v'", len(enabledChecks), enabledChecks)
+		t.Errorf("Expected more than 10 checks to be enabled, but got '%v' from '%v'",
+			len(enabledChecks), enabledChecks)
 	}
 
 	badChecks := getIncompatibleChecks()
 	for _, badCheck := range badChecks {
 		if stringInSlice(badCheck, enabledChecks) {
-			t.Errorf("Expected incompatible kube-linter check '%v' to not be enabled, but it was in the enabled list '%v'", badCheck, enabledChecks)
+			t.Errorf("Expected incompatible kube-linter check '%v' to not be enabled, " +
+				"but it was in the enabled list '%v'",
+				badCheck, enabledChecks)
 		}
 	}
 }

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -1,7 +1,6 @@
 package validations
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
@@ -25,34 +24,30 @@ const (
 )
 
 var (
-	loadOnceWithCustomCheck sync.Once
-	loadOnceWithAllChecks   sync.Once
 	ve                      validationEngine
 	loadErr                 error
 )
 
 func createEngineWithCustomCheck() (validationEngine, error) {
-	loadOnceWithCustomCheck.Do(func() {
-		ve = validationEngine{
-			config: config.Config{
-				CustomChecks: []config.Check{
-					{
-						Name:     checkName,
-						Template: "minimum-replicas",
-						Scope: &config.ObjectKindsDesc{
-							ObjectKinds: []string{"DeploymentLike"},
-						},
-						Params: map[string]interface{}{"minReplicas": 3},
+	ve = validationEngine{
+		config: config.Config{
+			CustomChecks: []config.Check{
+				{
+					Name:     checkName,
+					Template: "minimum-replicas",
+					Scope: &config.ObjectKindsDesc{
+						ObjectKinds: []string{"DeploymentLike"},
 					},
-				},
-				Checks: config.ChecksConfig{
-					AddAllBuiltIn:        false,
-					DoNotAutoAddDefaults: true,
+					Params: map[string]interface{}{"minReplicas": 3},
 				},
 			},
-		}
-		loadErr = ve.InitRegistry()
-	})
+			Checks: config.ChecksConfig{
+				AddAllBuiltIn:        false,
+				DoNotAutoAddDefaults: true,
+			},
+		},
+	}
+	loadErr = ve.InitRegistry()
 	if loadErr != nil {
 		return validationEngine{}, loadErr
 	}
@@ -60,18 +55,16 @@ func createEngineWithCustomCheck() (validationEngine, error) {
 }
 
 func createEngineWithAllChecks() (validationEngine, error) {
-	loadOnceWithAllChecks.Do(func() {
-		ve = validationEngine{
-			config: config.Config{
-				CustomChecks: []config.Check{},
-				Checks: config.ChecksConfig{
-					AddAllBuiltIn:        true,
-					DoNotAutoAddDefaults: false,
-				},
+	ve = validationEngine{
+		config: config.Config{
+			CustomChecks: []config.Check{},
+			Checks: config.ChecksConfig{
+				AddAllBuiltIn:        true,
+				DoNotAutoAddDefaults: false,
 			},
-		}
-		loadErr = ve.InitRegistry()
-	})
+		},
+	}
+	loadErr = ve.InitRegistry()
 	if loadErr != nil {
 		return validationEngine{}, loadErr
 	}

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -127,7 +127,7 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 	badChecks := getIncompatibleChecks()
 	allKubeLinterChecks, err := getAllBuiltInKubeLinterChecks()
 	if err != nil {
-		t.Fatalf("Got unexpected error while determining total number of checks in kube-linter: %v", err)
+		t.Fatalf("Got unexpected error while getting all checks built-into kube-linter: %v", err)
 	}
 	expectedNumChecks := len(allKubeLinterChecks) - len(badChecks)
 

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -125,11 +125,11 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 	}
 
 	badChecks := getIncompatibleChecks()
-	totalNumKubeLinterChecks, err := getTotalNumKubeLinterChecks()
+	allKubeLinterChecks, err := getAllBuiltInKubeLinterChecks()
 	if err != nil {
 		t.Fatalf("Got unexpected error while determining total number of checks in kube-linter: %v", err)
 	}
-	expectedNumChecks := totalNumKubeLinterChecks - len(badChecks)
+	expectedNumChecks := len(allKubeLinterChecks) - len(badChecks)
 
 	enabledChecks := e.EnabledChecks()
 	if len(enabledChecks) != expectedNumChecks {
@@ -155,21 +155,22 @@ func stringInSlice(a string, list []string) bool {
 	return false
 }
 
-func getTotalNumKubeLinterChecks() (int, error) {
+// getAllBuiltInKubeLinterChecks returns every check built-into kube-linter (including checks that DVO disables)
+func getAllBuiltInKubeLinterChecks() ([]string, error) {
 	ve := validationEngine{
 		config: newEngineConfigWithAllChecks(),
 	}
 	registry := checkregistry.New()
 	if err := builtinchecks.LoadInto(registry); err != nil {
 		log.Error(err, "failed to load built-in validations")
-		return 0, err
+		return nil, err
 	}
 
 	enabledChecks, err := configresolver.GetEnabledChecksAndValidate(&ve.config, registry)
 	if err != nil {
 		log.Error(err, "error finding enabled validations")
-		return 0, err
+		return nil, err
 	}
 
-	return len(enabledChecks), nil
+	return enabledChecks, nil
 }

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -11,9 +11,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"golang.stackrox.io/kube-linter/pkg/config"
-	"golang.stackrox.io/kube-linter/pkg/checkregistry"
 	"golang.stackrox.io/kube-linter/pkg/builtinchecks"
+	"golang.stackrox.io/kube-linter/pkg/checkregistry"
+	"golang.stackrox.io/kube-linter/pkg/config"
 	"golang.stackrox.io/kube-linter/pkg/configresolver"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -22,7 +22,6 @@ import (
 const (
 	checkName = "test-minimum-replicas"
 )
-
 
 func newEngine(c config.Config) (validationEngine, error) {
 	ve := validationEngine{
@@ -135,7 +134,7 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 	enabledChecks := e.EnabledChecks()
 	if len(enabledChecks) != expectedNumChecks {
 		t.Errorf("Expected exactly %v checks to be enabled, but got '%v' checks from list '%v'",
-		expectedNumChecks, len(enabledChecks), enabledChecks)
+			expectedNumChecks, len(enabledChecks), enabledChecks)
 	}
 
 	for _, badCheck := range badChecks {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -1,7 +1,6 @@
 package validations
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
@@ -22,33 +21,30 @@ const (
 )
 
 var (
-	loadOnce sync.Once
 	ve       validationEngine
 	loadErr  error
 )
 
 func createEngine() (validationEngine, error) {
-	loadOnce.Do(func() {
-		ve = validationEngine{
-			config: config.Config{
-				CustomChecks: []config.Check{
-					{
-						Name:     checkName,
-						Template: "minimum-replicas",
-						Scope: &config.ObjectKindsDesc{
-							ObjectKinds: []string{"DeploymentLike"},
-						},
-						Params: map[string]interface{}{"minReplicas": 3},
+	ve = validationEngine{
+		config: config.Config{
+			CustomChecks: []config.Check{
+				{
+					Name:     checkName,
+					Template: "minimum-replicas",
+					Scope: &config.ObjectKindsDesc{
+						ObjectKinds: []string{"DeploymentLike"},
 					},
-				},
-				Checks: config.ChecksConfig{
-					AddAllBuiltIn:        false,
-					DoNotAutoAddDefaults: true,
+					Params: map[string]interface{}{"minReplicas": 3},
 				},
 			},
-		}
-		loadErr = ve.InitRegistry()
-	})
+			Checks: config.ChecksConfig{
+				AddAllBuiltIn:        false,
+				DoNotAutoAddDefaults: true,
+			},
+		},
+	}
+	loadErr = ve.InitRegistry()
 	if loadErr != nil {
 		return validationEngine{}, loadErr
 	}
@@ -56,18 +52,16 @@ func createEngine() (validationEngine, error) {
 }
 
 func createEngineWithAllChecks() (validationEngine, error) {
-	loadOnce.Do(func() {
-		ve = validationEngine{
-			config: config.Config{
-				CustomChecks: []config.Check{},
-				Checks: config.ChecksConfig{
-					AddAllBuiltIn:        true,
-					DoNotAutoAddDefaults: false,
-				},
+	ve = validationEngine{
+		config: config.Config{
+			CustomChecks: []config.Check{},
+			Checks: config.ChecksConfig{
+				AddAllBuiltIn:        true,
+				DoNotAutoAddDefaults: false,
 			},
-		}
-		loadErr = ve.InitRegistry()
-	})
+		},
+	}
+	loadErr = ve.InitRegistry()
 	if loadErr != nil {
 		return validationEngine{}, loadErr
 	}
@@ -137,7 +131,7 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 
 	enabledChecks := e.EnabledChecks()
 	if len(enabledChecks) <= 10 {
-		t.Errorf("Expected more than 10 checks to be enabled, but got '%v'", enabledChecks)
+		t.Errorf("Expected more than 10 checks to be enabled, but got '%v' from '%v'", len(enabledChecks), enabledChecks)
 	}
 
 	badChecks := getIncompatibleChecks()

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -25,7 +25,7 @@ var (
 	loadErr  error
 )
 
-func createEngine() (validationEngine, error) {
+func createEngineWithCustomCheck() (validationEngine, error) {
 	ve = validationEngine{
 		config: config.Config{
 			CustomChecks: []config.Check{
@@ -80,7 +80,7 @@ func createTestDeployment(replicas int32) (*appsv1.Deployment, error) {
 }
 
 func TestRunValidationsIssueCorrection(t *testing.T) {
-	e, err := createEngine()
+	e, err := createEngineWithCustomCheck()
 	if err != nil {
 		t.Errorf("Error creating validation engine %v", err)
 	}

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -23,9 +23,9 @@ const (
 
 var (
 	loadOnceWithCustomCheck sync.Once
-	loadOnceWithAllChecks 	sync.Once
-	ve       				validationEngine
-	loadErr  				error
+	loadOnceWithAllChecks   sync.Once
+	ve                      validationEngine
+	loadErr                 error
 )
 
 func createEngineWithCustomCheck() (validationEngine, error) {
@@ -145,7 +145,7 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 	badChecks := getIncompatibleChecks()
 	for _, badCheck := range badChecks {
 		if stringInSlice(badCheck, enabledChecks) {
-			t.Errorf("Expected incompatible kube-linter check '%v' to not be enabled, " +
+			t.Errorf("Expected incompatible kube-linter check '%v' to not be enabled, "+
 				"but it was in the enabled list '%v'",
 				badCheck, enabledChecks)
 		}
@@ -153,10 +153,10 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 }
 
 func stringInSlice(a string, list []string) bool {
-    for _, b := range list {
-        if b == a {
-            return true
-        }
-    }
-    return false
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -57,6 +57,8 @@ func (ve *validationEngine) LoadConfig(path string) error {
 }
 
 func (ve *validationEngine) InitRegistry() error {
+	disableIncompatibleChecks(&ve.config)
+
 	registry := checkregistry.New()
 	if err := builtinchecks.LoadInto(registry); err != nil {
 		log.Error(err, "failed to load built-in validations")
@@ -143,4 +145,22 @@ func InitializeValidationEngine(path string) error {
 	}
 
 	return err
+}
+
+// disableIncompatibleChecks will forcibly update a kube-linter config to disable checks that are incompatible with DVO
+func disableIncompatibleChecks(c *config.Config) {
+	// the same check name may be in the exclude list multiple times; this is OK
+	c.Checks.Exclude = append(c.Checks.Exclude, getIncompatibleChecks()...)
+}
+
+// getIncompatibleChecks returns an array of kube-linter check names that are incompatible with DVO
+func getIncompatibleChecks() []string {
+	// these checks involve kube-linter comparing properties from multiple kubernetes objects at once
+	// (e.g. "non-existent-service-account" checks that all serviceaccounts referenced by deployment objects exist as serviceaccount objects)
+	// DVO currently only performs a check against kubernetes object at a time, so these checks that compare multiple objects together will always fail
+	return []string{
+		"dangling-service",
+		"non-existent-service-account",
+		"non-isolated-pod",
+	}
 }

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -148,16 +148,16 @@ func InitializeValidationEngine(path string) error {
 }
 
 // disableIncompatibleChecks will forcibly update a kube-linter config to disable checks that are incompatible with DVO
+// the same check name may end up in the exclude list multiple times as a result of this; this is OK
 func disableIncompatibleChecks(c *config.Config) {
-	// the same check name may be in the exclude list multiple times; this is OK
 	c.Checks.Exclude = append(c.Checks.Exclude, getIncompatibleChecks()...)
 }
 
 // getIncompatibleChecks returns an array of kube-linter check names that are incompatible with DVO
+// these checks involve kube-linter comparing properties from multiple kubernetes objects at once
+// (e.g. "non-existent-service-account" checks that all serviceaccounts referenced by deployment objects exist as serviceaccount objects)
+// DVO currently only performs a check against kubernetes object at a time, so these checks that compare multiple objects together will always fail
 func getIncompatibleChecks() []string {
-	// these checks involve kube-linter comparing properties from multiple kubernetes objects at once
-	// (e.g. "non-existent-service-account" checks that all serviceaccounts referenced by deployment objects exist as serviceaccount objects)
-	// DVO currently only performs a check against kubernetes object at a time, so these checks that compare multiple objects together will always fail
 	return []string{
 		"dangling-service",
 		"non-existent-service-account",

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -156,7 +156,7 @@ func disableIncompatibleChecks(c *config.Config) {
 // getIncompatibleChecks returns an array of kube-linter check names that are incompatible with DVO
 // these checks involve kube-linter comparing properties from multiple kubernetes objects at once
 // (e.g. "non-existent-service-account" checks that all serviceaccounts referenced by deployment objects exist as serviceaccount objects)
-// DVO currently only performs a check against kubernetes object at a time, so these checks that compare multiple objects together will always fail
+// DVO currently only performs a check against a single kubernetes object at a time, so these checks that compare multiple objects together will always fail
 func getIncompatibleChecks() []string {
 	return []string{
 		"dangling-service",

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -148,18 +148,18 @@ func InitializeValidationEngine(path string) error {
 }
 
 // disableIncompatibleChecks will forcibly update a kube-linter config
-// to disable checks that are incompatible with DVO
-// the same check name may end up in the exclude list multiple times as a result of this; this is OK
+// to disable checks that are incompatible with DVO.
+// the same check name may end up in the exclude list multiple times as a result of this; this is OK.
 func disableIncompatibleChecks(c *config.Config) {
 	c.Checks.Exclude = append(c.Checks.Exclude, getIncompatibleChecks()...)
 }
 
 // getIncompatibleChecks returns an array of kube-linter check names that are incompatible with DVO
-// these checks involve kube-linter comparing properties from multiple kubernetes objects at once
+// these checks involve kube-linter comparing properties from multiple kubernetes objects at once.
 // (e.g. "non-existent-service-account" checks that all serviceaccounts referenced by deployment objects
-// exist as serviceaccount objects)
+// exist as serviceaccount objects).
 // DVO currently only performs a check against a single kubernetes object at a time,
-// so these checks that compare multiple objects together will always fail
+// so these checks that compare multiple objects together will always fail.
 func getIncompatibleChecks() []string {
 	return []string{
 		"dangling-service",

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -147,7 +147,8 @@ func InitializeValidationEngine(path string) error {
 	return err
 }
 
-// disableIncompatibleChecks will forcibly update a kube-linter config to disable checks that are incompatible with DVO
+// disableIncompatibleChecks will forcibly update a kube-linter config
+// to disable checks that are incompatible with DVO
 // the same check name may end up in the exclude list multiple times as a result of this; this is OK
 func disableIncompatibleChecks(c *config.Config) {
 	c.Checks.Exclude = append(c.Checks.Exclude, getIncompatibleChecks()...)
@@ -155,8 +156,10 @@ func disableIncompatibleChecks(c *config.Config) {
 
 // getIncompatibleChecks returns an array of kube-linter check names that are incompatible with DVO
 // these checks involve kube-linter comparing properties from multiple kubernetes objects at once
-// (e.g. "non-existent-service-account" checks that all serviceaccounts referenced by deployment objects exist as serviceaccount objects)
-// DVO currently only performs a check against a single kubernetes object at a time, so these checks that compare multiple objects together will always fail
+// (e.g. "non-existent-service-account" checks that all serviceaccounts referenced by deployment objects
+// exist as serviceaccount objects)
+// DVO currently only performs a check against a single kubernetes object at a time,
+// so these checks that compare multiple objects together will always fail
 func getIncompatibleChecks() []string {
 	return []string{
 		"dangling-service",


### PR DESCRIPTION
This will force DVO to disable kube-linter checks that don't work correctly in DVO. Also adds a test.