### PR TITLE
"check_description" and "check_remediation" labels for metrics

### DIFF
--- a/pkg/validations/base.go
+++ b/pkg/validations/base.go
@@ -25,10 +25,7 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 	// If the object was deleted, then just delete the metrics and
 	// do not run any validations
 	if isDeleted {
-		for _, registeredCheck := range engine.registeredChecks {
-			fullPromLabelsForCheck := getFullPromLabels(basePromLabels, registeredCheck)
-			engine.DeleteMetrics(fullPromLabelsForCheck)
-		}
+		engine.DeleteMetrics(basePromLabels)
 		return
 	}
 

--- a/pkg/validations/base.go
+++ b/pkg/validations/base.go
@@ -50,8 +50,8 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 	engine.ClearMetrics(result.Reports, promLabels)
 
 	for _, report := range result.Reports {
-		check, err := engine.getCheckByName(report.Check)
-		if err != nil {
+		check, ok := engine.registeredChecks[report.Check]
+		if !ok {
 			log.Error(err, "Failed to get check '%s' by name", report.Check)
 			return
 		}

--- a/pkg/validations/base.go
+++ b/pkg/validations/base.go
@@ -50,19 +50,17 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 	engine.ClearMetrics(result.Reports, promLabels)
 
 	for _, report := range result.Reports {
-		checkDescription := ""
 		check, err := engine.getCheckByName(report.Check)
 		if err != nil {
 			log.Error(err, "Failed to get check '%s' by name", report.Check)
 			return
 		}
-		checkDescription = check.Description
 		logger := log.WithValues(
 			"request.namespace", request.Namespace,
 			"request.name", request.Name,
 			"kind", kind,
 			"validation", report.Check,
-			"check_description", checkDescription,
+			"check_description", check.Description,
 			"check_remediation", report.Remediation,
 			"check_failure_reason", report.Diagnostic.Message,
 		)

--- a/pkg/validations/base.go
+++ b/pkg/validations/base.go
@@ -1,6 +1,8 @@
 package validations
 
 import (
+	"fmt"
+
 	"github.com/app-sre/deployment-validation-operator/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -50,9 +52,9 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 	engine.ClearMetrics(result.Reports, promLabels)
 
 	for _, report := range result.Reports {
-		check, ok := engine.registeredChecks[report.Check]
-		if !ok {
-			log.Error(err, "Failed to get check '%s' by name", report.Check)
+		check, err := engine.GetCheckByName(report.Check)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Failed to get check '%s' by name", report.Check))
 			return
 		}
 		logger := log.WithValues(

--- a/pkg/validations/base.go
+++ b/pkg/validations/base.go
@@ -16,12 +16,20 @@ var log = logf.Log.WithName("validations")
 // RunValidations will run all the registered validations
 func RunValidations(request reconcile.Request, obj client.Object, kind string, isDeleted bool) {
 	log.V(2).Info("validation", "kind", kind)
-	promLabels := getPromLabels(request.Name, request.Namespace, kind)
+	basePromLabels := getBasePromLabels(
+		request.Namespace,
+		request.Name,
+		kind,
+	)
 
 	// If the object was deleted, then just delete the metrics and
 	// do not run any validations
+	fullPromLabels := engine.CheckRegistry
 	if isDeleted {
-		engine.DeleteMetrics(promLabels)
+		for _, check := range engine.CheckRegistry() {
+			fullPromLabels = getFullPromLabels(basePromLabels, check)
+			engine.DeleteMetrics(fullPromLabels)
+		}
 		return
 	}
 
@@ -43,19 +51,24 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 
 	// Clear labels from past run to ensure only results from this run
 	// are reflected in the metrics
-	engine.ClearMetrics(result.Reports, promLabels)
+	engine.ClearMetrics(result.Reports, basePromLabels)
 
 	for _, report := range result.Reports {
 		logger := log.WithValues(
 			"request.namespace", request.Namespace,
 			"request.name", request.Name,
 			"kind", kind,
-			"validation", report.Check)
+			"validation", report.Check,
+			"check_description", result.GetCheck(report.Check).Description,
+			"check_remediation", report.Remediation,
+			"check_failure_reason", report.Diagnostic.Message,
+		)
 		metric := engine.GetMetric(report.Check)
 		if metric == nil {
 			log.Error(nil, "no metric found for validation", report.Check)
 		} else {
-			metric.With(promLabels).Set(1)
+			fullPromLabels = getFullPromLabels(basePromLabels, check)
+			metric.With(fullPromLabels).Set(1)
 			logger.Info(report.Remediation)
 		}
 	}

--- a/pkg/validations/base.go
+++ b/pkg/validations/base.go
@@ -16,7 +16,7 @@ var log = logf.Log.WithName("validations")
 // RunValidations will run all the registered validations
 func RunValidations(request reconcile.Request, obj client.Object, kind string, isDeleted bool) {
 	log.V(2).Info("validation", "kind", kind)
-	basePromLabels := getBasePromLabels(
+	promLabels := getBasePromLabels(
 		request.Namespace,
 		request.Name,
 		kind,
@@ -25,7 +25,7 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 	// If the object was deleted, then just delete the metrics and
 	// do not run any validations
 	if isDeleted {
-		engine.DeleteMetrics(basePromLabels)
+		engine.DeleteMetrics(promLabels)
 		return
 	}
 
@@ -47,7 +47,7 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 
 	// Clear labels from past run to ensure only results from this run
 	// are reflected in the metrics
-	engine.ClearMetrics(result.Reports, basePromLabels)
+	engine.ClearMetrics(result.Reports, promLabels)
 
 	for _, report := range result.Reports {
 		checkDescription := ""
@@ -70,7 +70,7 @@ func RunValidations(request reconcile.Request, obj client.Object, kind string, i
 		if metric == nil {
 			log.Error(nil, "no metric found for validation", report.Check)
 		} else {
-			metric.With(basePromLabels).Set(1)
+			metric.With(promLabels).Set(1)
 			logger.Info(report.Remediation)
 		}
 	}

--- a/pkg/validations/base.go
+++ b/pkg/validations/base.go
@@ -16,7 +16,7 @@ var log = logf.Log.WithName("validations")
 // RunValidations will run all the registered validations
 func RunValidations(request reconcile.Request, obj client.Object, kind string, isDeleted bool) {
 	log.V(2).Info("validation", "kind", kind)
-	promLabels := getBasePromLabels(
+	promLabels := getPromLabels(
 		request.Namespace,
 		request.Name,
 		kind,

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -22,7 +22,10 @@ import (
 )
 
 const (
-	checkName = "test-minimum-replicas"
+	customCheck_name = "test-minimum-replicas"
+	customCheck_description = "some description"
+	customCheck_remediation = "some remediation"
+	customCheck_template = "minimum-replicas"
 )
 
 func newEngine(c config.Config) (validationEngine, error) {
@@ -38,10 +41,10 @@ func newEngine(c config.Config) (validationEngine, error) {
 
 func newCustomCheck() config.Check {
 	return config.Check{
-		Name:        checkName,
-		Description: "some description",
-		Remediation: "some remediation",
-		Template:    "minimum-replicas",
+		Name:        customCheck_name,
+		Description: customCheck_description,
+		Remediation: customCheck_remediation,
+		Template:    customCheck_template,
 		Scope: &config.ObjectKindsDesc{
 			ObjectKinds: []string{"DeploymentLike"},
 		},
@@ -104,7 +107,7 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	labels := getPromLabels(request.Namespace, request.Name, "Deployment")
 
-	metric, err := engine.GetMetric(checkName).GetMetricWith(labels)
+	metric, err := engine.GetMetric(customCheck.Name).GetMetricWith(labels)
 	if err != nil {
 		t.Errorf("Error getting prometheus metric: %v", err)
 	}
@@ -121,7 +124,7 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 	}
 
 	if metricValue := int(prom_tu.ToFloat64(metric)); metricValue != 1 {
-		t.Errorf("Deployment test failed %#v: got %d want %d", checkName, metricValue, 1)
+		t.Errorf("Deployment test failed %#v: got %d want %d", customCheck.Name, metricValue, 1)
 	}
 
 	// Problem resolved
@@ -133,13 +136,13 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 	// The 'GetMetricWith()' function will create a new metric with provided labels if it
 	// does not exist. The default value of a metric is 0. Therefore, a value of 0 implies we
 	// successfully cleared the metric label combination.
-	metric, err = engine.GetMetric(checkName).GetMetricWith(labels)
+	metric, err = engine.GetMetric(customCheck.Name).GetMetricWith(labels)
 	if err != nil {
 		t.Errorf("Error getting prometheus metric: %v", err)
 	}
 
 	if metricValue := int(prom_tu.ToFloat64(metric)); metricValue != 0 {
-		t.Errorf("Deployment test failed %#v: got %d want %d", checkName, metricValue, 0)
+		t.Errorf("Deployment test failed %#v: got %d want %d", customCheck.Name, metricValue, 0)
 	}
 }
 

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -101,7 +101,7 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	RunValidations(request, deployment, testutils.ObjectKind(deployment), false)
 
-	labels := getBasePromLabels(request.Namespace, request.Name, "Deployment")
+	labels := getPromLabels(request.Namespace, request.Name, "Deployment")
 
 	metric, err := engine.GetMetric(checkName).GetMetricWith(labels)
 	if err != nil {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -2,6 +2,7 @@ package validations
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
@@ -106,6 +107,12 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 	metric, err := engine.GetMetric(checkName).GetMetricWith(labels)
 	if err != nil {
 		t.Errorf("Error getting prometheus metric: %v", err)
+	}
+
+	const expectedConstLabelSubString = "" +
+		"constLabels: {check_description=\"some description\",check_remediation=\"some remediation\"}"
+	if !strings.Contains(metric.Desc().String(), expectedConstLabelSubString) {
+		t.Errorf("Metric is missing expected constant labels!")
 	}
 
 	if metricValue := int(prom_tu.ToFloat64(metric)); metricValue != 1 {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -126,7 +126,7 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	// Metric with label combination should be successfully cleared because problem was resolved.
 	// The 'GetMetricWith()' function will create a new metric with provided labels if it
-	// does not exist. The default value of a metric 0. Therefore, a value of 0 implies we
+	// does not exist. The default value of a metric is 0. Therefore, a value of 0 implies we
 	// successfully cleared the metric label combination.
 	metric, err = engine.GetMetric(checkName).GetMetricWith(labels)
 	if err != nil {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -38,10 +38,10 @@ func newEngine(c config.Config) (validationEngine, error) {
 
 func newCustomCheck() config.Check {
 	return config.Check{
-		Name:     checkName,
+		Name:        checkName,
 		Description: "some description",
 		Remediation: "some remediation",
-		Template: "minimum-replicas",
+		Template:    "minimum-replicas",
 		Scope: &config.ObjectKindsDesc{
 			ObjectKinds: []string{"DeploymentLike"},
 		},

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	customCheck_name = "test-minimum-replicas"
+	customCheck_name        = "test-minimum-replicas"
 	customCheck_description = "some description"
 	customCheck_remediation = "some remediation"
-	customCheck_template = "minimum-replicas"
+	customCheck_template    = "minimum-replicas"
 )
 
 func newEngine(c config.Config) (validationEngine, error) {
@@ -112,15 +112,15 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 		t.Errorf("Error getting prometheus metric: %v", err)
 	}
 
-	expectedConstLabelSubString := fmt.Sprintf("" +
+	expectedConstLabelSubString := fmt.Sprintf(""+
 		"constLabels: {check_description=\"%s\",check_remediation=\"%s\"}",
 		customCheck.Description,
 		customCheck.Remediation,
 	)
 	if !strings.Contains(metric.Desc().String(), expectedConstLabelSubString) {
 		t.Errorf("Metric is missing expected constant labels! Expected:\n%s\nGot:\n%s",
-		expectedConstLabelSubString,
-		metric.Desc().String())
+			expectedConstLabelSubString,
+			metric.Desc().String())
 	}
 
 	if metricValue := int(prom_tu.ToFloat64(metric)); metricValue != 1 {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	customCheck_name        = "test-minimum-replicas"
-	customCheck_description = "some description"
-	customCheck_remediation = "some remediation"
-	customCheck_template    = "minimum-replicas"
+	customCheckName        = "test-minimum-replicas"
+	customCheckDescription = "some description"
+	customCheckRemediation = "some remediation"
+	customCheckTemplate    = "minimum-replicas"
 )
 
 func newEngine(c config.Config) (validationEngine, error) {
@@ -41,10 +41,10 @@ func newEngine(c config.Config) (validationEngine, error) {
 
 func newCustomCheck() config.Check {
 	return config.Check{
-		Name:        customCheck_name,
-		Description: customCheck_description,
-		Remediation: customCheck_remediation,
-		Template:    customCheck_template,
+		Name:        customCheckName,
+		Description: customCheckDescription,
+		Remediation: customCheckRemediation,
+		Template:    customCheckTemplate,
 		Scope: &config.ObjectKindsDesc{
 			ObjectKinds: []string{"DeploymentLike"},
 		},

--- a/pkg/validations/gen.go
+++ b/pkg/validations/gen.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package validations

--- a/pkg/validations/utils.go
+++ b/pkg/validations/utils.go
@@ -7,15 +7,38 @@ import (
 	"github.com/app-sre/deployment-validation-operator/config"
 
 	"github.com/prometheus/client_golang/prometheus"
+	kubelinterconfig "golang.stackrox.io/kube-linter/pkg/config"
 )
 
-func getPromLabels(name, namespace, kind string) prometheus.Labels {
-	return prometheus.Labels{"namespace": namespace, "name": name, "kind": kind}
+func getBasePromLabels(namespace, name, kind string) prometheus.Labels {
+	return prometheus.Labels{
+		"namespace": namespace,
+		"name": name,
+		"kind": kind,
+	}
 }
 
-func newGaugeVecMetric(name, help string, labelNames []string) *prometheus.GaugeVec {
-	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("%s_%s", strings.ReplaceAll(config.OperatorName, "-", "_"), name),
-		Help: help,
-	}, labelNames)
+func getFullPromLabels(basePromLabels prometheus.Labels, check kubelinterconfig.Check,
+	) prometheus.Labels {
+	fullPromLabels := prometheus.Labels{
+		"check_description": check.Description,
+		"check_remediation": check.Remediation,
+	}
+	for k, v := range basePromLabels {
+		fullPromLabels[k] = v
+	}
+	return fullPromLabels
+}
+
+func newGaugeVecMetric(
+	name, help string, labelNames []string, constLabels prometheus.Labels,
+	) *prometheus.GaugeVec {
+	return prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: fmt.Sprintf("%s_%s", strings.ReplaceAll(config.OperatorName, "-", "_"), name),
+			Help: help,
+			ConstLabels: constLabels,
+		},
+		labelNames,
+	)
 }

--- a/pkg/validations/utils.go
+++ b/pkg/validations/utils.go
@@ -7,27 +7,14 @@ import (
 	"github.com/app-sre/deployment-validation-operator/config"
 
 	"github.com/prometheus/client_golang/prometheus"
-	kubelinterconfig "golang.stackrox.io/kube-linter/pkg/config"
 )
 
-func getBasePromLabels(namespace, name, kind string) prometheus.Labels {
+func getPromLabels(namespace, name, kind string) prometheus.Labels {
 	return prometheus.Labels{
 		"namespace": namespace,
 		"name": name,
 		"kind": kind,
 	}
-}
-
-func getFullPromLabels(basePromLabels prometheus.Labels, check kubelinterconfig.Check,
-	) prometheus.Labels {
-	fullPromLabels := prometheus.Labels{
-		"check_description": check.Description,
-		"check_remediation": check.Remediation,
-	}
-	for k, v := range basePromLabels {
-		fullPromLabels[k] = v
-	}
-	return fullPromLabels
 }
 
 func newGaugeVecMetric(

--- a/pkg/validations/utils.go
+++ b/pkg/validations/utils.go
@@ -12,18 +12,18 @@ import (
 func getPromLabels(namespace, name, kind string) prometheus.Labels {
 	return prometheus.Labels{
 		"namespace": namespace,
-		"name": name,
-		"kind": kind,
+		"name":      name,
+		"kind":      kind,
 	}
 }
 
 func newGaugeVecMetric(
 	name, help string, labelNames []string, constLabels prometheus.Labels,
-	) *prometheus.GaugeVec {
+) *prometheus.GaugeVec {
 	return prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: fmt.Sprintf("%s_%s", strings.ReplaceAll(config.OperatorName, "-", "_"), name),
-			Help: help,
+			Name:        fmt.Sprintf("%s_%s", strings.ReplaceAll(config.OperatorName, "-", "_"), name),
+			Help:        help,
 			ConstLabels: constLabels,
 		},
 		labelNames,

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -29,11 +29,11 @@ import (
 var engine validationEngine
 
 type validationEngine struct {
-	config        		config.Config
-	registry      		checkregistry.CheckRegistry
-	enabledChecks 		[]string
-	registeredChecks 	[]config.Check
-	metrics       		map[string]*prometheus.GaugeVec
+	config           config.Config
+	registry         checkregistry.CheckRegistry
+	enabledChecks    []string
+	registeredChecks []config.Check
+	metrics          map[string]*prometheus.GaugeVec
 }
 
 func (ve *validationEngine) CheckRegistry() checkregistry.CheckRegistry {
@@ -101,7 +101,8 @@ func (ve *validationEngine) InitRegistry() error {
 		ve.registeredChecks = append(ve.registeredChecks, check.Spec)
 		metric := newGaugeVecMetric(
 			strings.ReplaceAll(check.Spec.Name, "-", "_"),
-			fmt.Sprintf("Description: %s ; Remediation: %s", check.Spec.Description, check.Spec.Remediation),
+			fmt.Sprintf("Description: %s ; Remediation: %s",
+				check.Spec.Description, check.Spec.Remediation),
 			[]string{"namespace", "name", "kind"},
 			prometheus.Labels{
 				"check_description": check.Spec.Description,

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -168,7 +168,7 @@ func InitializeValidationEngine(path string) error {
 	return err
 }
 
-// getCheckByName will return an instantiatedCheck with a name matching the parameter.
+// getCheckByName will return a kube-linter check with a name matching the parameter.
 // If the check is not found, an error is returned.
 func (ve *validationEngine) getCheckByName(name string) (config.Check, error) {
 	for _, check := range ve.registeredChecks {

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -133,7 +133,7 @@ func (ve *validationEngine) DeleteMetrics(labels prometheus.Labels) {
 	}
 }
 
-func (ve *validationEngine) ClearMetrics(reports []diagnostic.WithContext, baseLabels prometheus.Labels) {
+func (ve *validationEngine) ClearMetrics(reports []diagnostic.WithContext, labels prometheus.Labels) {
 	// Create a list of validation names for use to delete the labels from any
 	// metric which isn't in the report but for which there is a metric
 	reportValidationNames := map[string]struct{}{}
@@ -142,9 +142,9 @@ func (ve *validationEngine) ClearMetrics(reports []diagnostic.WithContext, baseL
 	}
 
 	// Delete the labels for validations that aren't in the list of reports
-	for metricName := range ve.metrics {
-		if _, ok := reportValidationNames[metricName]; !ok {
-			ve.metrics[metricName].Delete(baseLabels)
+	for metricValidationName := range ve.metrics {
+		if _, ok := reportValidationNames[metricValidationName]; !ok {
+			ve.metrics[metricValidationName].Delete(labels)
 		}
 	}
 }

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -176,7 +176,7 @@ func (ve *validationEngine) getCheckByName(name string) (config.Check, error) {
 			return check, nil
 		}
 	}
-	return config.Check{}, fmt.Errorf("Failed to find check by name '%s", name)
+	return config.Check{}, fmt.Errorf("failed to find check by name '%s", name)
 }
 
 // disableIncompatibleChecks will forcibly update a kube-linter config

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -171,6 +171,14 @@ func InitializeValidationEngine(path string) error {
 	return err
 }
 
+func (ve *validationEngine) GetCheckByName(name string) (config.Check, error) {
+	check, ok := ve.registeredChecks[name]
+	if !ok {
+		return config.Check{}, fmt.Errorf("check '%s' is not registered", name)
+	}
+	return check, nil
+}
+
 // disableIncompatibleChecks will forcibly update a kube-linter config
 // to disable checks that are incompatible with DVO.
 // the same check name may end up in the exclude list multiple times as a result of this; this is OK.

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // Place any runtime dependencies as imports in this file.


### PR DESCRIPTION
(DVO-12)

Adds "check_description" and "check_remediation" as constant labels for check-validation metrics.

Prints out "check_description", "check_remediation", and "check_failure_reason" in logs.

Changes the "Help" string for metrics to include both a description and remediation.

Modifies a test to validate that metrics include the constant labels.

The validationEngine struct now stores `map[string]config.Check` for all registered checks, because I couldn't find any better way for `RunValidations()` to get access to kube-linter check descriptions.