### PR TITLE
Refactoring initializing engine due to new custom check conflicts

### DIFF
--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -177,7 +177,7 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 
 	err := intializeEngine()
 	if err != nil {
-		t.Errorf("Error getting prometheus metric: %v", err)
+		t.Errorf("Error initializing engine: %v", err)
 	}
 
 	badChecks := getIncompatibleChecks()

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -96,7 +96,7 @@ func intializeEngine(t *testing.T, customCheck ...config.Check) {
 			engine.config.CustomChecks[0] = customCheck[0]
 			return
 		}
-		// Intialize engine
+		// Initialize engine
 		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck[0]))
 		if err != nil {
 			t.Errorf("Error creating validation engine %v", err)
@@ -106,17 +106,17 @@ func intializeEngine(t *testing.T, customCheck ...config.Check) {
 		if initializeFlagAllChecks == 1 {
 			return
 		}
-		// Intialize engine
+		// Initialize engine
 		e, err := newEngine(newEngineConfigWithAllChecks())
 		if err != nil {
 			t.Errorf("Error creating validation engine %v", err)
 		}
 		engine = e
-		intializeFlagAllChecks = 1
+		initializeFlagAllChecks = 1
 	}
 
-	// Set intialize flag
-	intializeFlag = 1
+	// Set Initialize Flag
+	initializeFlag = 1
 }
 
 func TestRunValidationsIssueCorrection(t *testing.T) {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -54,26 +54,16 @@ func newCustomCheck() config.Check {
 	}
 }
 
-func newEngineConfigWithCustomCheck(customCheck ...config.Check) config.Config {
+func newEngineConfigWithCustomCheck(customCheck []config.Check) config.Config {
 
-	// Create custom config with custom check
-	customConfig := config.Config{
-		CustomChecks: []config.Check{
-			customCheck[0],
-		},
+	// Create custom config with custom check array
+	return config.Config{
+		CustomChecks: customCheck,
 		Checks: config.ChecksConfig{
 			AddAllBuiltIn:        false,
 			DoNotAutoAddDefaults: true,
 		},
 	}
-
-	// If there are multiple custom checks then input the remaining
-	if len(customCheck) > 1 {
-		for i := 1; i < len(customCheck); i++ {
-			customConfig.CustomChecks[i] = customCheck[i]
-		}
-	}
-	return customConfig
 }
 
 func newEngineConfigWithAllChecks() config.Config {
@@ -105,7 +95,7 @@ func intializeEngine(t *testing.T, customCheck ...config.Check) {
 	// Check if custom check has been set
 	if len(customCheck) > 0 {
 		// Initialize engine with custom check
-		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck...))
+		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck))
 		if err != nil {
 			t.Errorf("Error creating validation engine with custom checks %v", err)
 		}

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -87,7 +87,7 @@ func createTestDeployment(replicas int32) (*appsv1.Deployment, error) {
 	return &d, nil
 }
 
-func intializeEngine(t *testing.T, customCheck ...config.Check) {
+func intializeEngine(customCheck ...config.Check) {
 
 	// Reset global prometheus registry to avoid testing conflicts
 	metrics.Registry = prometheus.NewRegistry()
@@ -97,14 +97,16 @@ func intializeEngine(t *testing.T, customCheck ...config.Check) {
 		// Initialize engine with custom check
 		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck))
 		if err != nil {
-			t.Errorf("Error creating validation engine with custom checks %v", err)
+			fmt.Errorf("Error creating validation engine with custom checks %v", err)
+			return
 		}
 		engine = e
 	} else {
 		// Initialize engine for all checks
 		e, err := newEngine(newEngineConfigWithAllChecks())
 		if err != nil {
-			t.Errorf("Error creating validation engine with all checks %v", err)
+			fmt.Errorf("Error creating validation engine with all checks %v", err)
+			return
 		}
 		engine = e
 	}
@@ -114,7 +116,7 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	customCheck := newCustomCheck()
 
-	intializeEngine(t, customCheck)
+	intializeEngine(customCheck)
 
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "foo", Namespace: "bar"},
@@ -171,7 +173,7 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 func TestIncompatibleChecksAreDisabled(t *testing.T) {
 
-	intializeEngine(t)
+	intializeEngine()
 
 	badChecks := getIncompatibleChecks()
 	allKubeLinterChecks, err := getAllBuiltInKubeLinterChecks()

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -54,16 +54,26 @@ func newCustomCheck() config.Check {
 	}
 }
 
-func newEngineConfigWithCustomCheck(customCheck config.Check) config.Config {
-	return config.Config{
+func newEngineConfigWithCustomCheck(customCheck ...config.Check) config.Config {
+
+	// Create custom config with custom check
+	customConfig := config.Config{
 		CustomChecks: []config.Check{
-			customCheck,
+			customCheck[0],
 		},
 		Checks: config.ChecksConfig{
 			AddAllBuiltIn:        false,
 			DoNotAutoAddDefaults: true,
 		},
 	}
+
+	// If there are multiple custom checks then input the remaining
+	if len(customCheck) > 1 {
+		for i := 1; i < len(customCheck); i++ {
+			customConfig.CustomChecks[i] = customCheck[i]
+		}
+	}
+	return customConfig
 }
 
 func newEngineConfigWithAllChecks() config.Config {
@@ -95,14 +105,9 @@ func intializeEngine(t *testing.T, customCheck ...config.Check) {
 	// Check if custom check has been set
 	if len(customCheck) > 0 {
 		// Initialize engine with custom check
-		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck[0]))
+		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck...))
 		if err != nil {
 			t.Errorf("Error creating validation engine with custom checks %v", err)
-		}
-		if len(customCheck) > 1 {
-			for i := 1; i < len(customCheck); i++ {
-				e.config.CustomChecks[1] = customCheck[1]
-			}
 		}
 		engine = e
 	} else {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -177,7 +177,7 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 
 	err := intializeEngine()
 	if err != nil {
-		return
+		t.Errorf("Error getting prometheus metric: %v", err)
 	}
 
 	badChecks := getIncompatibleChecks()

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -117,7 +117,7 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	err := intializeEngine(customCheck)
 	if err != nil {
-		return
+		t.Errorf("Error initializing engine %v", err)
 	}
 
 	request := reconcile.Request{

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -97,14 +97,19 @@ func intializeEngine(t *testing.T, customCheck ...config.Check) {
 		// Initialize engine with custom check
 		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck[0]))
 		if err != nil {
-			t.Errorf("Error creating validation engine %v", err)
+			t.Errorf("Error creating validation engine with custom checks %v", err)
+		}
+		if len(customCheck) > 1 {
+			for i := 1; i < len(customCheck); i++ {
+				e.config.CustomChecks[1] = customCheck[1]
+			}
 		}
 		engine = e
 	} else {
 		// Initialize engine for all checks
 		e, err := newEngine(newEngineConfigWithAllChecks())
 		if err != nil {
-			t.Errorf("Error creating validation engine %v", err)
+			t.Errorf("Error creating validation engine with all checks %v", err)
 		}
 		engine = e
 	}

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -28,8 +28,8 @@ const (
 	customCheckTemplate    = "minimum-replicas"
 )
 
-var intializeFlag = 0
-var intializeFlagAllChecks = 0
+var initializeFlag = 0
+var initializeFlagAllChecks = 0
 
 func newEngine(c config.Config) (validationEngine, error) {
 	ve := validationEngine{
@@ -92,7 +92,7 @@ func intializeEngine(t *testing.T, customCheck ...config.Check) {
 
 	// Check if custom check has been set
 	if len(customCheck) > 0 {
-		if intializeFlag == 1 {
+		if initializeFlag == 1 {
 			engine.config.CustomChecks[0] = customCheck[0]
 			return
 		}
@@ -103,7 +103,7 @@ func intializeEngine(t *testing.T, customCheck ...config.Check) {
 		}
 		engine = e
 	} else {
-		if intializeFlagAllChecks == 1 {
+		if initializeFlagAllChecks == 1 {
 			return
 		}
 		// Intialize engine

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -87,7 +87,7 @@ func createTestDeployment(replicas int32) (*appsv1.Deployment, error) {
 	return &d, nil
 }
 
-func intializeEngine(customCheck ...config.Check) {
+func intializeEngine(customCheck ...config.Check) error {
 
 	// Reset global prometheus registry to avoid testing conflicts
 	metrics.Registry = prometheus.NewRegistry()
@@ -97,19 +97,18 @@ func intializeEngine(customCheck ...config.Check) {
 		// Initialize engine with custom check
 		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck))
 		if err != nil {
-			fmt.Errorf("Error creating validation engine with custom checks %v", err)
-			return
+			return fmt.Errorf("Error creating validation engine with custom checks %v", err)
 		}
 		engine = e
 	} else {
 		// Initialize engine for all checks
 		e, err := newEngine(newEngineConfigWithAllChecks())
 		if err != nil {
-			fmt.Errorf("Error creating validation engine with all checks %v", err)
-			return
+			return fmt.Errorf("Error creating validation engine with all checks %v", err)
 		}
 		engine = e
 	}
+	return nil
 }
 
 func TestRunValidationsIssueCorrection(t *testing.T) {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -89,9 +89,6 @@ func createTestDeployment(replicas int32) (*appsv1.Deployment, error) {
 
 func intializeEngine(customCheck ...config.Check) error {
 
-	// Reset global prometheus registry to avoid testing conflicts
-	metrics.Registry = prometheus.NewRegistry()
-
 	// Check if custom check has been set
 	if len(customCheck) > 0 {
 		// Initialize engine with custom check
@@ -114,6 +111,9 @@ func intializeEngine(customCheck ...config.Check) error {
 func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	customCheck := newCustomCheck()
+
+	// Reset global prometheus registry to avoid testing conflicts
+	metrics.Registry = prometheus.NewRegistry()
 
 	err := intializeEngine(customCheck)
 	if err != nil {
@@ -174,6 +174,9 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 }
 
 func TestIncompatibleChecksAreDisabled(t *testing.T) {
+
+	// Reset global prometheus registry to avoid testing conflicts
+	metrics.Registry = prometheus.NewRegistry()
 
 	err := intializeEngine()
 	if err != nil {

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -115,7 +115,10 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	customCheck := newCustomCheck()
 
-	intializeEngine(customCheck)
+	err := intializeEngine(customCheck)
+	if err != nil {
+		return
+	}
 
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "foo", Namespace: "bar"},
@@ -172,7 +175,10 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 func TestIncompatibleChecksAreDisabled(t *testing.T) {
 
-	intializeEngine()
+	err := intializeEngine()
+	if err != nil {
+		return
+	}
 
 	badChecks := getIncompatibleChecks()
 	allKubeLinterChecks, err := getAllBuiltInKubeLinterChecks()

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -116,8 +116,6 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	intializeEngine(t, customCheck)
 
-	//engine.config.CustomChecks[0] = customCheck
-
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "foo", Namespace: "bar"},
 	}

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -97,14 +97,14 @@ func intializeEngine(customCheck ...config.Check) error {
 		// Initialize engine with custom check
 		e, err := newEngine(newEngineConfigWithCustomCheck(customCheck))
 		if err != nil {
-			return fmt.Errorf("Error creating validation engine with custom checks %v", err)
+			return err
 		}
 		engine = e
 	} else {
 		// Initialize engine for all checks
 		e, err := newEngine(newEngineConfigWithAllChecks())
 		if err != nil {
-			return fmt.Errorf("Error creating validation engine with all checks %v", err)
+			return err
 		}
 		engine = e
 	}

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -177,7 +177,7 @@ func TestIncompatibleChecksAreDisabled(t *testing.T) {
 
 	err := intializeEngine()
 	if err != nil {
-		return
+		t.Errorf("Error initializing engine %v", err)
 	}
 
 	badChecks := getIncompatibleChecks()

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -89,6 +89,9 @@ func createTestDeployment(replicas int32) (*appsv1.Deployment, error) {
 
 func intializeEngine(customCheck ...config.Check) error {
 
+	// Reset global prometheus registry to avoid testing conflicts
+	metrics.Registry = prometheus.NewRegistry()
+
 	// Check if custom check has been set
 	if len(customCheck) > 0 {
 		// Initialize engine with custom check
@@ -111,9 +114,6 @@ func intializeEngine(customCheck ...config.Check) error {
 func TestRunValidationsIssueCorrection(t *testing.T) {
 
 	customCheck := newCustomCheck()
-
-	// Reset global prometheus registry to avoid testing conflicts
-	metrics.Registry = prometheus.NewRegistry()
 
 	err := intializeEngine(customCheck)
 	if err != nil {
@@ -175,12 +175,9 @@ func TestRunValidationsIssueCorrection(t *testing.T) {
 
 func TestIncompatibleChecksAreDisabled(t *testing.T) {
 
-	// Reset global prometheus registry to avoid testing conflicts
-	metrics.Registry = prometheus.NewRegistry()
-
 	err := intializeEngine()
 	if err != nil {
-		t.Errorf("Error initializing engine %v", err)
+		return
 	}
 
 	badChecks := getIncompatibleChecks()


### PR DESCRIPTION
When creating new custom checks within the validations package, if validation engine gets initialized  more then once, GO will throw a panic error. This is work set to remedy this issue.