### PR TITLE
Ensure metrics are deleted for resources in a deleted namespace

### DIFF
--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -88,7 +88,7 @@ func (gr *GenericReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 	deleted := err != nil && errors.IsNotFound(err)
 	gvk := instance.GetObjectKind().GroupVersionKind()
-	validations.RunValidations(request, instance, gvk.Kind, deleted)
+	validations.RunValidations(request, instance, gr.reconciledKind, deleted)
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -87,7 +87,6 @@ func (gr *GenericReconciler) Reconcile(ctx context.Context, request reconcile.Re
 	}
 
 	deleted := err != nil && errors.IsNotFound(err)
-	gvk := instance.GetObjectKind().GroupVersionKind()
 	validations.RunValidations(request, instance, gr.reconciledKind, deleted)
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
This MR fixes bug [DVO-31](https://issues.redhat.com/browse/DVO-31): Deleted Namespace and Kind still show in DVO grafana / prometheus.

Reconcile watches objects and triggers validations.RunValidations(), where DVO output is shipped to DVO's /metrics endpoint. Delete metric labels operations are also handled in RunValidations(). 

On deletion, gvk.Kind is an empty string for all resource types besides "Pod". This string is passed into RunValidations and is used to construct the prometheus labels for the associated metric.

When a deletion event is passed to RunValidations for non-pod resources (Deployment, ReplicaSet),  promLabels is missing the kind field, and as such can't associate the provided deletion event with the existing metrics. For an example nginx deployment, the prom labels do not exist / will return multiple labels.

```
promLabels := getPromLabels(
	request.Namespace,
	request.Name,
	kind,
)

promLabels := getPromLabels(
	'check',
	'nginx'
	'',
)
```

Passing `gr.reconciledKind` into RunValidations instead of `gvk.Kind` fixes this problem. Deployment and ReplicaSet kinds are passed to the validation method, and the promLabels are found and deleted.
