### PR TITLE
expose minimal prometheus metrics (DVO-23)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -34,9 +34,9 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsPort       	int32 	= 8383
-	metricsPath			string	= "metrics"
-	defaultConfigFile   	    = "config/deployment-validation-operator-config.yaml"
+	metricsPort       int32  = 8383
+	metricsPath       string = "metrics"
+	defaultConfigFile        = "config/deployment-validation-operator-config.yaml"
 )
 var log = logf.Log.WithName("DeploymentValidation")
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,9 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 
 	"github.com/spf13/pflag"
 )

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -169,9 +169,7 @@ func main() {
 }
 
 func initMetricsEndpoint() {
-	r := prometheus.NewRegistry()
-	handler := promhttp.HandlerFor(r, promhttp.HandlerOpts{})
-	http.Handle(fmt.Sprintf("/%s", metricsPath), handler)
+	http.Handle(fmt.Sprintf("/%s", metricsPath), promhttp.Handler())
 	go func() {
 		err := http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil)
 		log.Error(err, "Prometheus metrics server stopped unexpectedly")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -147,14 +147,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	log.Info(fmt.Sprintf("Initializing Prometheus metrics endpoint on %s", getFullMetricsEndpoint()))
+	dvo_prom.InitMetricsEndpoint(metricsPath, metricsPort)
+
 	log.Info("Initializing Validation Engine")
 	if err := validations.InitializeValidationEngine(configFile); err != nil {
 		log.Error(err, "Failed to initialize validation engine")
 		os.Exit(1)
 	}
-
-	log.Info(fmt.Sprintf("Initializing Prometheus metrics endpoint on %s", getFullMetricsEndpoint()))
-	dvo_prom.InitMetricsEndpoint(metricsPath, metricsPort)
 
 	log.Info("Starting")
 

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -87,8 +87,7 @@ func (gr *GenericReconciler) Reconcile(ctx context.Context, request reconcile.Re
 	}
 
 	deleted := err != nil && errors.IsNotFound(err)
-	gvk := instance.GetObjectKind().GroupVersionKind()
-	validations.RunValidations(request, instance, gvk.Kind, deleted)
+	validations.RunValidations(request, instance, gr.reconciledKind, deleted)
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -1,0 +1,25 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var PrometheusRegistry *prometheus.Registry
+
+var log = logf.Log.WithName("utils")
+
+func InitMetricsEndpoint(metricsPath string, metricsPort int32) {
+	PrometheusRegistry = prometheus.NewRegistry()
+	handler := promhttp.HandlerFor(PrometheusRegistry, promhttp.HandlerOpts{})
+	http.Handle(fmt.Sprintf("/%s", metricsPath), handler)
+	go func() {
+		err := http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil)
+		log.Error(err, "Prometheus metrics server stopped unexpectedly")
+	}()
+}

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -12,7 +12,7 @@ import (
 
 var PrometheusRegistry *prometheus.Registry
 
-var log = logf.Log.WithName("utils")
+var log = logf.Log.WithName("prometheus")
 
 func InitMetricsEndpoint(metricsPath string, metricsPort int32) {
 	PrometheusRegistry = prometheus.NewRegistry()

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -6,18 +6,23 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/prometheus/client_golang/prometheus"
+	// Import Prometheus resources
+	. "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var PrometheusRegistry *prometheus.Registry
+var PrometheusRegistry *Registry
 
 var log = logf.Log.WithName("utils")
 
 func InitMetricsEndpoint(metricsPath string, metricsPort int32) {
-	PrometheusRegistry = prometheus.NewRegistry()
+	PrometheusRegistry = NewRegistry()
+	PrometheusRegistry.MustRegister(NewProcessCollector(ProcessCollectorOpts{}))
+	PrometheusRegistry.MustRegister(NewGoCollector())
+
 	handler := promhttp.HandlerFor(PrometheusRegistry, promhttp.HandlerOpts{})
 	http.Handle(fmt.Sprintf("/%s", metricsPath), handler)
+
 	go func() {
 		err := http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil)
 		log.Error(err, "Prometheus metrics server stopped unexpectedly")

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -6,19 +6,22 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	// Import Prometheus resources
-	. "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var PrometheusRegistry *Registry
+var PrometheusRegistry *prometheus.Registry
 
 var log = logf.Log.WithName("utils")
 
 func InitMetricsEndpoint(metricsPath string, metricsPort int32) {
-	PrometheusRegistry = NewRegistry()
-	PrometheusRegistry.MustRegister(NewProcessCollector(ProcessCollectorOpts{}))
-	PrometheusRegistry.MustRegister(NewGoCollector())
+	PrometheusRegistry = prometheus.NewRegistry()
+	processCollector := prometheus.NewProcessCollector(
+		prometheus.ProcessCollectorOpts{},
+	)
+	goCollector := prometheus.NewGoCollector()
+	PrometheusRegistry.MustRegister(processCollector)
+	PrometheusRegistry.MustRegister(goCollector)
 
 	handler := promhttp.HandlerFor(PrometheusRegistry, promhttp.HandlerOpts{})
 	http.Handle(fmt.Sprintf("/%s", metricsPath), handler)

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	dvo_prom "github.com/app-sre/deployment-validation-operator/pkg/prometheus"
 	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,7 +20,6 @@ import (
 	"golang.stackrox.io/kube-linter/pkg/config"
 	"golang.stackrox.io/kube-linter/pkg/configresolver"
 
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -89,7 +89,7 @@ func createTestDeployment(replicas int32) (*appsv1.Deployment, error) {
 func initializeEngine(customCheck ...config.Check) error {
 
 	// Reset global prometheus registry to avoid testing conflicts
-	metrics.Registry = prometheus.NewRegistry()
+	dvo_prom.PrometheusRegistry = prometheus.NewRegistry()
 
 	// Check if custom check has been set
 	if len(customCheck) > 0 {

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	// Import checks from DVO
+	dvo_prom "github.com/app-sre/deployment-validation-operator/pkg/prometheus"
 	_ "github.com/app-sre/deployment-validation-operator/pkg/validations/all"
 
 	"golang.stackrox.io/kube-linter/pkg/builtinchecks"
@@ -108,7 +109,7 @@ func (ve *validationEngine) InitRegistry() error {
 				"check_remediation": check.Spec.Remediation,
 			},
 		)
-		prometheus.MustRegister(metric)
+		dvo_prom.PrometheusRegistry.MustRegister(metric)
 		validationMetrics[checkName] = metric
 	}
 

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	// Import checks from DVO
 	dvo_prom "github.com/app-sre/deployment-validation-operator/pkg/prometheus"
+	// Import checks from DVO
 	_ "github.com/app-sre/deployment-validation-operator/pkg/validations/all"
 
 	"golang.stackrox.io/kube-linter/pkg/builtinchecks"

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	dvo_prom "github.com/app-sre/deployment-validation-operator/pkg/prometheus"
+
 	// Import checks from DVO
 	_ "github.com/app-sre/deployment-validation-operator/pkg/validations/all"
 

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -19,8 +19,6 @@ import (
 	// Import and initialize all check templates from kube-linter
 	_ "golang.stackrox.io/kube-linter/pkg/templates/all"
 
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/spf13/viper"
@@ -110,7 +108,7 @@ func (ve *validationEngine) InitRegistry() error {
 				"check_remediation": check.Spec.Remediation,
 			},
 		)
-		metrics.Registry.MustRegister(metric)
+		prometheus.MustRegister(metric)
 		validationMetrics[checkName] = metric
 	}
 


### PR DESCRIPTION
Currently, DVO's `/metrics` endpoint exposes a great number of metrics, including those of the default prometheus go-client collectors, as well as metrics managed by the controller-runtime package.

This PR disables the `/metrics` endpoint managed by controller-runtime, and replaces it with a default and more minimal promhttp handler. In addition to the failing-validation metrics, this will cause DVO to expose only a few dozen non-validation metrics (e.g. goroutines, cpu, memory, http requests handled, etc) about DVO itself (as opposed to thousands of additional controller-runtime-managed metrics).

Prometheus-setup code is added to its own new package. This package manages the global Prometheus registry(which used to managed by controller-runtime).

Testing this on the app-sre-stage-01 cluster, this PR brings us down from 5k metrics to 2k metrics (99% of which begin with the `deployment_validation_operator_` prefix).

I have chosen to have this PR still expose a few dozen non-validation metrics (e.g. goroutines, cpu, memory, http requests handled, etc). I believe these metrics are invaluable for monitoring and troubleshooting DVO itself. Alternatively, if we truly want DVO to drop **_all_** non-validation metrics, that's easy to do, but this would be at the cost of operability of DVO imo.

Consideration for the future:
* Do we want there to be an optional configuration property to enable/disable the controller-runtime metrics on DVO? I'm thinking probably not, but this would be pretty easy to implement.