### PR TITLE
Altered prometheus operator to 1 replica and changed naming

### DIFF
--- a/deploy/observability/template.yaml
+++ b/deploy/observability/template.yaml
@@ -455,10 +455,10 @@ objects:
 - apiVersion: monitoring.coreos.com/v1
   kind: Prometheus
   metadata:
-    name: deployment-validation-operator
+    name: contoller-subscription
     namespace: ${NAMESPACE}
   spec:
-    replicas: 2
+    replicas: 1
     serviceAccountName: prometheus-k8s
     serviceMonitorSelector:
       matchLabels:

--- a/deploy/observability/template.yaml
+++ b/deploy/observability/template.yaml
@@ -455,7 +455,7 @@ objects:
 - apiVersion: monitoring.coreos.com/v1
   kind: Prometheus
   metadata:
-    name: contoller-subscription
+    name: deployment-validation-operator
     namespace: ${NAMESPACE}
   spec:
     replicas: 1


### PR DESCRIPTION
Current prometheus operator deploys 2 replicas and naming is confusing. Changing to 1 replica and altering naming convention.