### PR TITLE
add probes to deployment

### DIFF
--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -56,6 +56,9 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 8383
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
         env:
         - name: WATCH_NAMESPACE
           value: ""

--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -47,6 +47,17 @@ spec:
           limits:
             memory: "4Gi"
             cpu: "1"
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8383
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 8383
         env:
         - name: WATCH_NAMESPACE
           value: ""

--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -56,7 +56,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 8383
-          initialDelaySeconds: 30
+          initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 3
         env:

--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -48,15 +48,13 @@ spec:
             memory: "4Gi"
             cpu: "1"
         livenessProbe:
-          httpGet:
-            path: /metrics
+          tcpSocket:
             port: 8383
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 3
         readinessProbe:
-          httpGet:
-            path: /metrics
+          tcpSocket:
             port: 8383
         env:
         - name: WATCH_NAMESPACE


### PR DESCRIPTION
DVO should implement best practices it itself recommends.

since DVO's main function is to provide metrics related to DVO violations, IMO it makes sense to use the metrics endpoint as an indicator for readiness and health.