### PR TITLE
Iniital olm artifacts template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: dvo-selectorsyncset-template
+parameters:
+  - name: REGISTRY_IMG
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE_DIGEST
+    required: true
+  - name: REPO_NAME
+    value: deployment-validation-operator
+    required: true
+  - name: DISPLAY_NAME
+    value: Deployment Validation Operator
+    required: true
+  - name: CHANNEL
+    value: "alpha"
+    displayName: OLM subscription channel
+    description: OLM subscription channel
+    required: true
+objects:
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      annotations:
+        component-display-name: ${DISPLAY_NAME}
+        component-name: ${REPO_NAME}
+      labels:
+        managed.openshift.io/gitHash: ${IMAGE_TAG}
+        managed.openshift.io/gitRepoName: ${REPO_NAME}
+        managed.openshift.io/osd: "true"
+      name: deployment-validation-operator
+    spec:
+      clusterDeploymentSelector:
+        matchLabels:
+          api.openshift.com/managed: "true"
+      resourceApplyMode: Sync
+      resources:
+        - apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: openshift-deployment-validation-operator
+            labels:
+              openshift.io/cluster-monitoring: "true"
+        - apiVersion: operators.coreos.com/v1alpha1
+          kind: CatalogSource
+          metadata:
+            name: deployment-validation-operator-catalog
+            namespace: openshift-deployment-validation-operator
+          spec:
+            sourceType: grpc
+            image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+            displayName: Deployment Validation Operator
+            publisher: Red Hat
+        - apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: deployment-validation-operator-og
+            namespace: openshift-deployment-validation-operator
+            annotations:
+              olm.operatorframework.io/exclude-global-namespace-resolution: "true"
+          spec:
+            targetNamespaces:
+              - openshift-deployment-validation-operator
+        - apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: deployment-validation-operator
+            namespace: openshift-deployment-validation-operator
+          spec:
+            channel: ${CHANNEL}
+            name: deployment-validation-operator
+            source: deployment-validation-operator-catalog
+            sourceNamespace: openshift-deployment-validation-operator


### PR DESCRIPTION
**What**
Created an initial olm artifacts template based on what I can infer from the olm artifacts template in addon-operator.

**Why**
App-interface saas file will need to refer to this template file in order to create a selectorsyncset in hive.

I'm new at DVO and the hive/olm/app-interface deployment model/processes so I may have naively created this template in that case please let me know. I partially tested dvo deployment on a local kind cluster with olm and used another hive kind cluster to test the SS.

