### PR TITLE
Added namespaces to ignore for platform

### DIFF
--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -65,7 +65,7 @@ spec:
         - name: OPERATOR_NAME
           value: "deployment-validation-operator"
         - name: NAMESPACE_IGNORE_PATTERN
-          value: "openshift.*|kube-.+"
+          value: "openshift.*|kube-.+|default|dedicated-admin"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Quick change to ensure OSD rollout of DVO accounts for all namespaces to ignore to ensure customer does not receive platform related recommendations