### PR TITLE
Adding network object for insight operator and namespace pattern ignore

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -82,6 +82,7 @@ objects:
           kind: NetworkPolicy
             metadata:
               name: allow-from-openshift-insights
+              namespace: openshift-deployment-validation-operator
           spec:
             podSelector: {}
             ingress:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -80,9 +80,9 @@ objects:
             sourceNamespace: openshift-deployment-validation-operator
         - apiVersion: networking.k8s.io/v1
           kind: NetworkPolicy
-            metadata:
-              name: allow-from-openshift-insights
-              namespace: openshift-deployment-validation-operator
+          metadata:
+            name: allow-from-openshift-insights
+            namespace: openshift-deployment-validation-operator
           spec:
             podSelector: {}
             ingress:
@@ -92,3 +92,18 @@ objects:
                       name: openshift-insights
           policyTypes:
             - Ingress
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: deployment-validation-operator-metrics
+            labels:
+              name: deployment-validation-operator
+              namespace: openshift-deployment-validation-operator
+          spec:
+            ports:
+            - name: http-metrics
+              port: 8383
+              protocol: TCP
+              targetPort: 8383
+            selector:
+              name: deployment-validation-operator

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -71,6 +71,23 @@ objects:
             namespace: openshift-deployment-validation-operator
           spec:
             channel: ${CHANNEL}
+            config:
+              env:
+              - name: "NAMESPACE_IGNORE_PATTERN"
+                value: "openshift.*|kube-.*|default|dedicated-admin"
             name: deployment-validation-operator
             source: deployment-validation-operator-catalog
             sourceNamespace: openshift-deployment-validation-operator
+        - apiVersion: networking.k8s.io/v1
+          kind: NetworkPolicy
+            metadata:
+              name: allow-from-openshift-insights
+          spec:
+            podSelector: {}
+            ingress:
+              - from:
+                - namespaceSelector:
+                    matchLabels:
+                      name: openshift-insights
+          policyTypes:
+            - Ingress


### PR DESCRIPTION
Adding network policy to allow ingress from only the openshift insights operator. Also added namespace pattern exclusions to not have DVO alert on platform level stuff to customer.