### PR TITLE
Adding infra-node to assure operator deploys on infra node

### DIFF
--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -22,6 +22,8 @@ spec:
         name: deployment-validation-operator
         app: deployment-validation-operator
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Adding node selector to assure DVO is deployed on infra nodes for OSD deployment