### PR TITLE
Restrict rollout of SSS

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -36,6 +36,13 @@ objects:
       clusterDeploymentSelector:
         matchLabels:
           api.openshift.com/managed: "true"
+        matchExpressions:
+          - key: hive.openshift.io/version-major-minor
+            operator: NotIn
+            values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10"]
+          - key: api.openshift.com/environment
+            operator: In
+            values: ["staging", "integration"]
       resourceApplyMode: Sync
       resources:
         - apiVersion: v1


### PR DESCRIPTION
This adds in additional restrictions to the rollout of DVO:
- Only roll out to clusters 4.11+
- Only roll out to clusters in the staging and integration environments