### PR TITLE
OLM can now upgrade even if the CSV fails

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -69,6 +69,8 @@ objects:
             annotations:
               olm.operatorframework.io/exclude-global-namespace-resolution: "true"
           spec:
+            upgradeStrategy:
+              name: TechPreviewUnsafeFailForward
             targetNamespaces:
               - openshift-deployment-validation-operator
         - apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Using https://olm.operatorframework.io/docs/advanced-tasks/unsafe-fail-forward-upgrades/#using-unsafefailforward-upgrades, so we can exit from a failed CSV in a fleet-wide event, just by releasing a new version.