### PR TITLE
fix updateStrategy

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -69,8 +69,7 @@ objects:
             annotations:
               olm.operatorframework.io/exclude-global-namespace-resolution: "true"
           spec:
-            upgradeStrategy:
-              name: TechPreviewUnsafeFailForward
+            upgradeStrategy: TechPreviewUnsafeFailForward
             targetNamespaces:
               - openshift-deployment-validation-operator
         - apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Previous object was being rejected with this message

```
for: "object": OperatorGroup.operators.coreos.com "deployment-validation-operator-og" is invalid: [spec.upgradeStrategy: Invalid value: "object": spec.upgradeStrategy in body must be of type string: "object", spec.upgradeStrategy: Unsupported value: map[string]interface {}{}: supported values: "Default", "TechPreviewUnsafeFailForward"]')
```