### PR TITLE
Improve apiResource listing mechansim for deciding resources to be validated

### DIFF
--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -113,9 +113,16 @@ func (gr *GenericReconciler) Start(ctx context.Context) error {
 }
 
 func (gr *GenericReconciler) reconcileEverything(ctx context.Context) error {
-	apiResources, err := reconcileResourceList(gr.discovery)
+	var log = logf.Log.WithName("reconcileEverything")
+	apiResources, err := reconcileResourceList(gr.discovery, gr.client.Scheme())
 	if err != nil {
 		return fmt.Errorf("retrieving resources to reconcile: %w", err)
+	}
+
+	for i, resource := range apiResources {
+		log.Info("apiResource", "no:", i+1, "Group:", resource.Group,
+			"Version:", resource.Version,
+			"Kind:", resource.Kind)
 	}
 
 	gr.watchNamespaces.resetCache()

--- a/pkg/controller/reconcileobjects.go
+++ b/pkg/controller/reconcileobjects.go
@@ -1,40 +1,110 @@
 package controller
 
 import (
+	"fmt"
+	"strings"
+
 	"golang.stackrox.io/kube-linter/pkg/objectkinds"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 )
 
-func reconcileResourceList(client discovery.DiscoveryInterface) ([]metav1.APIResource, error) {
-	apiResourceLists, err := client.ServerPreferredResources()
+type resourceSet struct {
+	scheme       *runtime.Scheme
+	apiResources map[schema.GroupKind]metav1.APIResource
+}
+
+func newResourceSet(scheme *runtime.Scheme) *resourceSet {
+	return &resourceSet{
+		scheme:       scheme,
+		apiResources: make(map[schema.GroupKind]metav1.APIResource),
+	}
+}
+
+func (s *resourceSet) Add(key schema.GroupKind, val metav1.APIResource) error {
+	if isSubResource(val) {
+		return nil
+	}
+
+	if ok, err := isRegisteredKubeLinterKind(val); err != nil {
+		return fmt.Errorf("checking if resource %s, is registered KubeLinter kind: %w", val.String(), err)
+	} else if !ok {
+		return nil
+	}
+
+	if !s.scheme.Recognizes(gvkFromMetav1APIResource(val)) {
+		return nil
+	}
+
+	if existing, ok := s.apiResources[key]; ok {
+		existing.Version = s.getPriorityVersion(existing.Group, existing.Version, val.Version)
+
+		s.apiResources[key] = existing
+	} else {
+		s.apiResources[key] = val
+	}
+	return nil
+}
+
+func (s *resourceSet) getPriorityVersion(group, existingVer, currentVer string) string {
+	gv := s.scheme.PrioritizedVersionsAllGroups()
+	for _, v := range gv {
+		if v.Group != group {
+			continue
+		}
+		if v.Version == existingVer {
+			return existingVer
+		}
+		if v.Version == currentVer {
+			return currentVer
+		}
+	}
+	return existingVer
+}
+
+func (s *resourceSet) ToSlice() []metav1.APIResource {
+	res := make([]metav1.APIResource, 0, len(s.apiResources))
+
+	for _, v := range s.apiResources {
+		res = append(res, v)
+	}
+
+	return res
+}
+
+func reconcileResourceList(client discovery.DiscoveryInterface,
+	scheme *runtime.Scheme) ([]metav1.APIResource, error) {
+	set := newResourceSet(scheme)
+
+	_, apiResourceLists, err := client.ServerGroupsAndResources()
 	if err != nil {
 		return nil, err
 	}
-	apiResources := []metav1.APIResource{}
-	for _, apiResourceGroup := range apiResourceLists {
-		gv, err := schema.ParseGroupVersion(apiResourceGroup.GroupVersion)
+
+	for _, apiResourceList := range apiResourceLists {
+		gv, err := schema.ParseGroupVersion(apiResourceList.GroupVersion)
 		if err != nil {
 			return nil, err
 		}
-		for _, apiResource := range apiResourceGroup.APIResources {
-
-			apiResource.Version = gv.Version
-			apiResource.Group = gv.Group
-
-			canValidate, err := isRegisteredKubeLinterKind(apiResource)
-			if err != nil {
-				return nil, err
+		for _, rsc := range apiResourceList.APIResources {
+			rsc.Group, rsc.Version = gv.Group, gv.Version
+			key := schema.GroupKind{
+				Group: gv.Group,
+				Kind:  rsc.Kind,
 			}
-
-			if !canValidate {
-				continue
+			if err := set.Add(key, rsc); err != nil {
+				return nil, fmt.Errorf("adding resource %s to set: %w", rsc.String(), err)
 			}
-			apiResources = append(apiResources, apiResource)
 		}
 	}
-	return apiResources, nil
+	return set.ToSlice(), nil
+}
+
+// isSubResource returns true if the apiResource.Name has a "/" in it eg: pod/status
+func isSubResource(apiResource metav1.APIResource) bool {
+	return strings.Contains(apiResource.Name, "/")
 }
 
 func isRegisteredKubeLinterKind(rsrc metav1.APIResource) (bool, error) {


### PR DESCRIPTION
Add a check to ensure that an APIResource (gvk) supported by the server is registered in the client-go scheme

Add a mechanism to make sure that the gvk of the APIResource is chosen based on what is supported by client scheme when server supports more than one version.

eg: server supports `batch/v1/CronJobs` and `batch/v1beta1/CronJob` but client knows only about 
`batch/v1beta1/CronJob`. In this case `batch/v1beta1/CronJob` will be used in queries.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>