### PR TITLE
Boilerplate: Update to 2bdc59eec75cc9dcd03c2d790e7bea9138579ce7

### DIFF
--- a/boilerplate/_data/last-boilerplate-commit
+++ b/boilerplate/_data/last-boilerplate-commit
@@ -1,1 +1,1 @@
-f1ce2ebcab3cd03ddb7c46d1c8c96a810d5d5ca1
+2bdc59eec75cc9dcd03c2d790e7bea9138579ce7

--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -71,7 +71,7 @@ function check_bundle_contents_cmd() {
 # Check we are running an opm supported container engine
 function check_opm_supported_container_engine() {
     local image_builder=${1}
-    if [[ "$image_builder" != docker* && "$image_builder" != "podman" ]]; then
+    if [[ "$image_builder" != "docker" && "$image_builder" != "podman" ]]; then
         # opm error messages are obscure. Let's make this clear
         log "image_builder $image_builder is not one of docker or podman"
         return 1
@@ -309,7 +309,7 @@ function main() {
     opm_local_executable=$(setup_local_executable opm)
     grpcurl_local_executable=$(setup_local_executable grpcurl)
     engine_cmd=$(setup_authenticated_registry_command)
-    image_builder=$(basename "$CONTAINER_ENGINE")
+    image_builder=$(basename "$CONTAINER_ENGINE" | awk '{print $1}')
 
     check_opm_supported_container_engine "$image_builder" || return 1
 


### PR DESCRIPTION
Conventions:
- openshift/golang-osd-operator: Update ---
https://github.com/openshift/boilerplate/compare/f1ce2ebcab3cd03ddb7c46d1c8c96a810d5d5ca1...2bdc59eec75cc9dcd03c2d790e7bea9138579ce7

commit: 94825f3cf075658be2cac702c0b64e6f037ef7c4
author: Andrew Pantuso
fix: fix opm-build-push to use proper container engine name