### PR TITLE
Apantuso/owners cleanup

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,9 +9,6 @@ approvers:
 - maorfr
 reviewers:
 - jmelis
-- BumbleFeng
-- bkez322
-- hlipsig
 - npecka
 - ajpantuso
 - apahim

--- a/OWNERS
+++ b/OWNERS
@@ -7,9 +7,11 @@ approvers:
 - ajpantuso
 - apahim
 - maorfr
+- ncaak
 reviewers:
 - jmelis
 - npecka
 - ajpantuso
 - apahim
 - maorfr
+- ncaak


### PR DESCRIPTION
### Summary

- Removes emeritus reviewers from `OWNERS` file to avoid pinging them for reviews on new PR's
- Adds Issac from CCX as an approver/reviewer to facilitate ownership transfer