### PR TITLE
Add CCX members suitable to maintain the project in the future

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,8 @@ approvers:
 - apahim
 - maorfr
 - ncaak
+- rluders
+- tremes
 reviewers:
 - jmelis
 - npecka
@@ -15,3 +17,5 @@ reviewers:
 - apahim
 - maorfr
 - ncaak
+- rluders
+- tremes


### PR DESCRIPTION
## summary
* Adds Tomas Remes and Ricardo Lüders, from CCX team, as approvers/reviewers to facilitate ownership transfer