### PR TITLE
deployment updates to run on 4.12

### DIFF
--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -22,17 +22,15 @@ spec:
         name: deployment-validation-operator
         app: deployment-validation-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
         - key: node-role.kubernetes.io/infra
           operator: Exists
           effect: NoSchedule
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/infra
-                operator: Exists
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -48,8 +46,6 @@ spec:
       - image: quay.io/deployment-validation-operator/dv-operator:latest
         imagePullPolicy: Always
         name: deployment-validation-operator
-        args:
-        - --config /config/deployment-validation-operator-config.yaml
         resources:
           requests:
             memory: "200Mi"
@@ -91,6 +87,9 @@ spec:
           mountPath: /config
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
       volumes:
       - name: dvo-config
         configMap:


### PR DESCRIPTION
I needed those updates to be able to deploy DVO to my 4.12 OCP cluster. Do we need it? Not sure, but I think we need some reliable way to test & develop easily. 