### PR TITLE
Add ccx member to reviewers/approvers owners list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,7 @@ approvers:
 - ncaak
 - rluders
 - tremes
+- JoaoFula
 reviewers:
 - jmelis
 - npecka
@@ -19,3 +20,4 @@ reviewers:
 - ncaak
 - rluders
 - tremes
+- JoaoFula


### PR DESCRIPTION
### summary
* Adding Joao Fula, member of ccx team, to approvers and reviewers list