### PR TITLE
Exclude cluster scoped resources from KubeLinter analysis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	go.uber.org/multierr v1.8.0
 	golang.stackrox.io/kube-linter v0.6.3
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
@@ -105,6 +104,7 @@ require (
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/net v0.9.0 // indirect

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -198,7 +198,9 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 	return relatedObjects, nil
 }
 
-func (gr *GenericReconciler) processNamespacedResources(ctx context.Context, gvks []schema.GroupVersionKind, namespaces *[]namespace) error {
+func (gr *GenericReconciler) processNamespacedResources(
+	ctx context.Context, gvks []schema.GroupVersionKind, namespaces *[]namespace) error {
+
 	for _, ns := range *namespaces {
 		relatedObjects, err := gr.groupAppObjects(ctx, ns.name, gvks)
 		if err != nil {

--- a/pkg/controller/generic_reconciler_test.go
+++ b/pkg/controller/generic_reconciler_test.go
@@ -396,3 +396,41 @@ func unstructuredToNames(objs []*unstructured.Unstructured) []string {
 	}
 	return names
 }
+
+func Test_getNamespacedResourcesGVK(t *testing.T) {
+	unitTests := []struct {
+		name   string
+		arg    []metav1.APIResource
+		result []schema.GroupVersionKind
+	}{
+		{
+			name: "Received resource is on a namespace and it's returned as GVK",
+			arg: []metav1.APIResource{{
+				Group: "test", Version: "v1", Kind: "Ingress", Namespaced: true,
+			}},
+			result: []schema.GroupVersionKind{{
+				Group: "test", Version: "v1", Kind: "Ingress",
+			}},
+		},
+		{
+			name: "Received resource is not on a namespace and it's not returned as GVK",
+			arg: []metav1.APIResource{{
+				Group: "test", Version: "v1", Kind: "Ingress", Namespaced: false,
+			}},
+			result: []schema.GroupVersionKind{},
+		},
+	}
+
+	for _, ut := range unitTests {
+		t.Run(ut.name, func(t *testing.T) {
+			// Given
+			gr := GenericReconciler{}
+
+			// When
+			test := gr.getNamespacedResourcesGVK(ut.arg)
+
+			// Assert
+			assert.Equal(t, ut.result, test)
+		})
+	}
+}


### PR DESCRIPTION
### summary

* Removed code that processed cluster-wide resources
* Removed unexported methods associated to that code

### misc

* Add unit test to fixed method
* Minor refactor on how the namespaced resources are processed

### tracking

https://issues.redhat.com/browse/DVO-102