### PR TITLE
DVO-105: extends the logic of matching "app" labels

### DIFF
--- a/pkg/utils/app_label.go
+++ b/pkg/utils/app_label.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// AppSelector is a helper type which
+// consists of LabelSelectorOperator type and
+// string values
+type AppSelector struct {
+	Operator metav1.LabelSelectorOperator
+	Values   sets.Set[string]
+}
+
+// GetAppSelectors tries to get values (there can be more) of the "app" label.
+// First it tries to read "metadata.labels.app" path (e.g for Deployments) if not found,
+// then it tries to read "spec.selector.matchLabels.app" path (e.g for PodDisruptionBudget) if not found,
+// then it tries to read "spec.selector.matchExpressions" path.
+func GetAppSelectors(object *unstructured.Unstructured) ([]AppSelector, error) {
+	appLabel, found, err := unstructured.NestedString(object.Object, "metadata", "labels", "app")
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return []AppSelector{
+			{
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   sets.New(appLabel),
+			},
+		}, nil
+	}
+	// if not found try spec.selector.matchLabels path - e.g for PDB resource
+	appLabel, found, err = unstructured.NestedString(object.Object,
+		"spec", "selector", "matchLabels", "app")
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return []AppSelector{
+			{
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   sets.New(appLabel),
+			},
+		}, nil
+	}
+	// if not found try spec.selector.matchExpressions path
+	expressions, found, err := unstructured.NestedSlice(object.Object, "spec", "selector", "matchExpressions")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("can't find any 'app' label for %s resource from %s namespace",
+			object.GetName(), object.GetNamespace())
+	}
+	appSelectors := parseMatchExpressions(expressions)
+	return appSelectors, nil
+}
+
+// parseMatchExpressions tries to parse provided untyped slice of expressions
+// and return a slice of appSelectors. Any expression key with a value other than "app" is skipped.
+// Label selector operator "DoesNotExist" is skipped too.
+func parseMatchExpressions(expressions []interface{}) []AppSelector {
+	appSelectors := []AppSelector{}
+	for _, exp := range expressions {
+		expAsMap, ok := exp.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if expAsMap["key"] != "app" {
+			continue
+		}
+		appSelector := AppSelector{}
+		switch expAsMap["operator"] {
+		case "In":
+			values, _, err := unstructured.NestedStringSlice(expAsMap, "values")
+			if err != nil {
+				continue
+			}
+			appSelector.Operator = metav1.LabelSelectorOpIn
+			appSelector.Values = sets.New(values...)
+		case "NotIn":
+			values, _, err := unstructured.NestedStringSlice(expAsMap, "values")
+			if err != nil {
+				continue
+			}
+			appSelector.Operator = metav1.LabelSelectorOpNotIn
+			appSelector.Values = sets.New(values...)
+		case "Exists":
+			appSelector.Operator = metav1.LabelSelectorOpExists
+		case "DoesNotExist":
+			continue
+		}
+		appSelectors = append(appSelectors, appSelector)
+	}
+	return appSelectors
+}

--- a/pkg/utils/app_label_test.go
+++ b/pkg/utils/app_label_test.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestGetAppSelectors(t *testing.T) {
+	tests := []struct {
+		testName               string
+		object                 runtime.Object
+		expectedLabelSelectors []AppSelector
+		expectedError          error
+	}{
+		{
+			testName: "Pod with defined label",
+			object: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "app-A",
+					Labels: map[string]string{
+						"app": "app-A",
+					},
+				},
+			},
+			expectedLabelSelectors: []AppSelector{
+				{
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   sets.New("app-A"),
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			testName: "Pod with undefined label",
+			object: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-app",
+					Namespace: "test",
+				},
+			},
+			expectedLabelSelectors: nil,
+			expectedError: fmt.
+				Errorf("can't find any 'app' label for empty-app resource from test namespace"),
+		},
+		{
+			testName: "PDB with defined selector label",
+			object: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pdb-A",
+					Namespace: "test",
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "app-with-pdb",
+						},
+					},
+				},
+			},
+			expectedLabelSelectors: []AppSelector{
+				{
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   sets.New("app-with-pdb"),
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			testName: "PDB with empty selector",
+			object: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-app",
+					Namespace: "test",
+				},
+			},
+			expectedLabelSelectors: nil,
+			expectedError: fmt.
+				Errorf("can't find any 'app' label for empty-app resource from test namespace"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.object)
+			assert.NoError(t, err)
+			u := &unstructured.Unstructured{
+				Object: o,
+			}
+			appSelectors, err := GetAppSelectors(u)
+			if tt.expectedError != nil {
+				assert.Error(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedLabelSelectors, appSelectors)
+		})
+	}
+}


### PR DESCRIPTION
DVO tries to group objects with the same `app` label value. Before this update, the operator tried to read the following paths to get the `app` label value:

- `metadata.labels.app` 
- `spec.selector.matchLabels.app` 

The problem with this approach is that labels can match using `matchExpressions`. An example is:
```
key: app
operator: NotIn
values:
- foo
- bar
```
which means match everything except of resources with `app=foo` or `app=bar`. This is a more effective approach but more complex. 

The problem is that we don't know the set of `app` label values (in a namespace) in advance. So the logic here is to read/process all the "inclusive" label selectors, which builds the set of known `app` label values and then process the other `app` label selectors such as `Exists` and `NotIn`.  
