### PR TITLE
Make catalogsource compatible with restricted SCC enforcement

### DIFF
--- a/deploy/openshift/deployment-validation-operator-olm-with-polling.yaml
+++ b/deploy/openshift/deployment-validation-operator-olm-with-polling.yaml
@@ -10,6 +10,8 @@ objects:
     name: ${SOURCE}
   spec:
     sourceType: grpc
+    grpcPodConfig:
+      securityContextConfig: restricted
     image: ${IMAGE}:${IMAGE_TAG}
     displayName: Deployment Validation Operator
     publisher: ${CATALOG_PUBLISHER}

--- a/deploy/openshift/deployment-validation-operator-olm.yaml
+++ b/deploy/openshift/deployment-validation-operator-olm.yaml
@@ -10,6 +10,8 @@ objects:
     name: ${SOURCE}
   spec:
     sourceType: grpc
+    grpcPodConfig:
+      securityContextConfig: restricted
     image: ${IMAGE}:${IMAGE_TAG}
     displayName: Deployment Validation Operator
     publisher: ${CATALOG_PUBLISHER}

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -62,6 +62,8 @@ objects:
             namespace: openshift-deployment-validation-operator
           spec:
             sourceType: grpc
+            grpcPodConfig:
+              securityContextConfig: restricted
             image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
             displayName: Deployment Validation Operator
             publisher: Red Hat


### PR DESCRIPTION
* Restricted SCC enforcement will be added with OCP 4.14
* Updating the catalogsource to allow the operator to get deployed
* Clusters that don't support the setting (<4.12) will ignore it

Jira: [OSD-15625](https://issues.redhat.com//browse/OSD-15625)