### PR TITLE
DVO-128: enable non-isolated Pod check & enhance group matching again

### DIFF
--- a/pkg/utils/app_label_test.go
+++ b/pkg/utils/app_label_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,9 +45,8 @@ func TestGetAppSelectors(t *testing.T) {
 					Namespace: "test",
 				},
 			},
-			expectedLabelSelectors: nil,
-			expectedError: fmt.
-				Errorf("can't find any 'app' label for empty-app resource from test namespace"),
+			expectedLabelSelectors: []AppSelector{},
+			expectedError:          nil,
 		},
 		{
 			testName: "PDB with defined selector label",
@@ -81,9 +79,8 @@ func TestGetAppSelectors(t *testing.T) {
 					Namespace: "test",
 				},
 			},
-			expectedLabelSelectors: nil,
-			expectedError: fmt.
-				Errorf("can't find any 'app' label for empty-app resource from test namespace"),
+			expectedLabelSelectors: []AppSelector{},
+			expectedError:          nil,
 		},
 	}
 

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -209,7 +209,7 @@ func getIncompatibleChecks() []string {
 	return []string{
 		"dangling-service",
 		"non-existent-service-account",
-		"non-isolated-pod",
+		//"non-isolated-pod",
 	}
 }
 


### PR DESCRIPTION
This enables the existing `nonisolated-pod` kube-linter check. I realized (when working & playing with this one) that the labels & selectors logic we have for grouping the objects is very poor. I created two new tasks which should be addressed:

- https://issues.redhat.com/browse/DVO-132
- https://issues.redhat.com/browse/DVO-133 