### PR TITLE
DVO-132: empty selector matches all the resource in the corresponding

### DIFF
--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -187,6 +187,14 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 // them in the 'relatedObjects' map.
 func processObjectLabelSelectors(obj *unstructured.Unstructured,
 	relatedObjects map[string][]*unstructured.Unstructured) {
+
+	// if the object has an empty non-null selector the add it to every known group
+	if utils.HasEmptySelector(obj) {
+		for k := range relatedObjects {
+			relatedObjects[k] = append(relatedObjects[k], obj)
+		}
+		return
+	}
 	appSelectors, err := utils.GetAppSelectors(obj)
 	if err != nil {
 		// swallow the error here. it will be too noisy to log

--- a/pkg/controller/generic_reconciler_test.go
+++ b/pkg/controller/generic_reconciler_test.go
@@ -407,6 +407,55 @@ func TestGroupAppObjects(t *testing.T) {
 				"B": {"statefulset-B", "pdb-not-in-A"},
 			},
 		},
+		{
+			name:      "Two Deployments and a PDB with empty selector matching both deployments",
+			namespace: "test",
+			objs: []client.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pdb",
+						Namespace: "test",
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{},
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-A",
+						Namespace: "test",
+						Labels: map[string]string{
+							"app": "A",
+						},
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-B",
+						Namespace: "test",
+						Labels: map[string]string{
+							"app": "B",
+						},
+					},
+				},
+			},
+			gvks: []schema.GroupVersionKind{
+				{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
+				{
+					Group:   "policy",
+					Kind:    "PodDisruptionBudget",
+					Version: "v1",
+				},
+			},
+			expectedNames: map[string][]string{
+				"A": {"app-A", "test-pdb"},
+				"B": {"app-B", "test-pdb"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/app_label.go
+++ b/pkg/utils/app_label.go
@@ -16,6 +16,19 @@ type AppSelector struct {
 	Values   sets.Set[string]
 }
 
+// HasEmptySelector checks whether of the "spec.selector" and "spec.podSelector" is defined, but empty.
+func HasEmptySelector(object *unstructured.Unstructured) bool {
+	selector, found, _ := unstructured.NestedMap(object.Object, "spec", "selector")
+	if found && len(selector) == 0 {
+		return true
+	}
+	podSelector, found, _ := unstructured.NestedMap(object.Object, "spec", "podSelector")
+	if found && len(podSelector) == 0 {
+		return true
+	}
+	return false
+}
+
 // GetAppSelectors tries to get values (there can be more) of the "app" label.
 // First it tries to read "metadata.labels.app" path (e.g for Deployments) if not found,
 // then it tries to read "spec.selector.matchLabels.app" path (e.g for PodDisruptionBudget) if not found,


### PR DESCRIPTION
namespace

If the resource has empty "selector" defined then it matches all the objects in the corresponding namespace. 