### PR TITLE
DVO-131: Fix default configuration with already watched rules 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ DVO performs validation checks using kube-linter. The checks configuration is mi
 
 To configure DVO with a different set of checks, create a ConfigMap in the cluster with the new checks configuration. An example of a configuration ConfigMap can be found [here](./deploy/openshift/configmap.yaml).
 
+If no custom configuration is found (the ConfigMap does not exist or does not contain a check declaration), the project sets the checks to the following list by default:
+* "pdb-max-unavailable"
+* "pdb-min-available"
+* "non-isolated-pod"
+* "unset-cpu-requirements"
+* "unset-memory-requirements"
+
 **constraint**: Currently, the configuration isn't continuously monitored and is only checked at startup. If a new set of checks is configured in a ConfigMap, the pod running DVO will need to be rebooted.
 
 ### Enabling checks

--- a/README.md
+++ b/README.md
@@ -106,9 +106,16 @@ DVO performs validation checks using kube-linter. The checks configuration is mi
 To configure DVO with a different set of checks, create a ConfigMap in the cluster with the new checks configuration. An example of a configuration ConfigMap can be found [here](./deploy/openshift/configmap.yaml).
 
 If no custom configuration is found (the ConfigMap does not exist or does not contain a check declaration), the project sets the checks to the following list by default:
+* "host-ipc"
+* "host-network"
+* "host-pid"
+* "non-isolated-pod"
 * "pdb-max-unavailable"
 * "pdb-min-available"
-* "non-isolated-pod"
+* "privilege-escalation-container"
+* "privileged-container"
+* "run-as-non-root"
+* "unsafe-sysctls"
 * "unset-cpu-requirements"
 * "unset-memory-requirements"
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ DVO performs validation checks using kube-linter. The checks configuration is mi
 
 To configure DVO with a different set of checks, create a ConfigMap in the cluster with the new checks configuration. An example of a configuration ConfigMap can be found [here](./deploy/openshift/configmap.yaml).
 
-If no custom configuration is found (the ConfigMap does not exist or does not contain a check declaration), the project sets the checks to the following list by default:
+If no custom configuration is found (the ConfigMap does not exist or does not contain a check declaration), the operator enables the following checks by default:
 * "host-ipc"
 * "host-network"
 * "host-pid"

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -8,12 +8,6 @@ metadata:
 data:
   deployment-validation-operator-config.yaml: |-
     checks:
-      # if doNotAutoAddDefaults is true, default checks are not automatically added.
-      doNotAutoAddDefaults: false
-
-      # addAllBuiltIn, if set, adds all built-in checks. This allows users to
-      # explicitly opt-out of checks that are not relevant using Exclude.
-      # Takes precedence over doNotAutoAddDefaults, if both are set.
-      addAllBuiltIn: true
-
-      exclude: ["access-to-create-pods", "access-to-secrets", "cluster-admin-role-binding", "default-service-account", "deprecated-service-account-field", "docker-sock", "drop-net-raw-capability", "env-var-secret", "exposed-services", "latest-tag", "mismatching-selector", "no-extensions-v1beta", "no-liveness-probe", "no-read-only-root-fs", "no-readiness-probe", "no-rolling-update-strategy", "privileged-ports", "read-secret-from-env-var", "required-annotation-email", "required-label-owner", "sensitive-host-mounts", "ssh-port", "unsafe-proc-mount", "use-namespace", "wildcard-in-rules", "writable-host-mount"]
+      doNotAutoAddDefaults: true
+      addAllBuiltIn: false
+      include: ["pdb-max-unavailable", "pdb-min-available", "non-isolated-pod", "unset-cpu-requirements", "unset-memory-requirements"]

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -10,4 +10,16 @@ data:
     checks:
       doNotAutoAddDefaults: true
       addAllBuiltIn: false
-      include: ["pdb-max-unavailable", "pdb-min-available", "non-isolated-pod", "unset-cpu-requirements", "unset-memory-requirements"]
+      include:
+      - "host-ipc"
+      - "host-network"
+      - "host-pid"
+      - "non-isolated-pod"
+      - "pdb-max-unavailable"
+      - "pdb-min-available"
+      - "privilege-escalation-container"
+      - "privileged-container"
+      - "run-as-non-root"
+      - "unsafe-sysctls"
+      - "unset-cpu-requirements"
+      - "unset-memory-requirements"

--- a/deploy/openshift/deployment-validation-operator-olm.yaml
+++ b/deploy/openshift/deployment-validation-operator-olm.yaml
@@ -47,7 +47,19 @@ objects:
       checks:
         doNotAutoAddDefaults: true
         addAllBuiltIn: false
-        include: ["pdb-max-unavailable", "pdb-min-available", "non-isolated-pod", "unset-cpu-requirements", "unset-memory-requirements"]
+        include:
+        - "host-ipc"
+        - "host-network"
+        - "host-pid"
+        - "non-isolated-pod"
+        - "pdb-max-unavailable"
+        - "pdb-min-available"
+        - "privilege-escalation-container"
+        - "privileged-container"
+        - "run-as-non-root"
+        - "unsafe-sysctls"
+        - "unset-cpu-requirements"
+        - "unset-memory-requirements"
 - apiVersion: v1
   kind: Service
   metadata:

--- a/deploy/openshift/deployment-validation-operator-olm.yaml
+++ b/deploy/openshift/deployment-validation-operator-olm.yaml
@@ -45,15 +45,9 @@ objects:
   data:
     deployment-validation-operator-config.yaml: |-
       checks:
-        # if doNotAutoAddDefaults is true, default checks are not automatically added.
-        doNotAutoAddDefaults: false
-
-        # addAllBuiltIn, if set, adds all built-in checks. This allows users to
-        # explicitly opt-out of checks that are not relevant using Exclude.
-        # Takes precedence over doNotAutoAddDefaults, if both are set.
-        addAllBuiltIn: true
-
-        exclude: ["access-to-create-pods", "access-to-secrets", "cluster-admin-role-binding", "default-service-account", "deprecated-service-account-field", "docker-sock", "drop-net-raw-capability", "env-var-secret", "exposed-services", "latest-tag", "mismatching-selector", "no-extensions-v1beta", "no-liveness-probe", "no-read-only-root-fs", "no-readiness-probe", "no-rolling-update-strategy", "privileged-ports", "read-secret-from-env-var", "required-annotation-email", "required-label-owner", "sensitive-host-mounts", "ssh-port", "unsafe-proc-mount", "use-namespace", "wildcard-in-rules", "writable-host-mount"]
+        doNotAutoAddDefaults: true
+        addAllBuiltIn: false
+        include: ["pdb-max-unavailable", "pdb-min-available", "non-isolated-pod", "unset-cpu-requirements", "unset-memory-requirements"]
 - apiVersion: v1
   kind: Service
   metadata:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -145,12 +145,6 @@ objects:
           data:
             deployment-validation-operator-config.yaml: |-
               checks:
-                # if doNotAutoAddDefaults is true, default checks are not automatically added.
-                doNotAutoAddDefaults: false
-
-                # addAllBuiltIn, if set, adds all built-in checks. This allows users to
-                # explicitly opt-out of checks that are not relevant using Exclude.
-                # Takes precedence over doNotAutoAddDefaults, if both are set.
-                addAllBuiltIn: true
-
-                exclude: ["access-to-create-pods", "access-to-secrets", "cluster-admin-role-binding", "default-service-account", "deprecated-service-account-field", "docker-sock", "drop-net-raw-capability", "env-var-secret", "exposed-services", "latest-tag", "mismatching-selector", "no-extensions-v1beta", "no-liveness-probe", "no-read-only-root-fs", "no-readiness-probe", "no-rolling-update-strategy", "privileged-ports", "read-secret-from-env-var", "required-annotation-email", "required-label-owner", "sensitive-host-mounts", "ssh-port", "unsafe-proc-mount", "use-namespace", "wildcard-in-rules", "writable-host-mount"]
+                doNotAutoAddDefaults: true
+                addAllBuiltIn: false
+                include: ["pdb-max-unavailable", "pdb-min-available", "non-isolated-pod", "unset-cpu-requirements", "unset-memory-requirements"]

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -147,4 +147,16 @@ objects:
               checks:
                 doNotAutoAddDefaults: true
                 addAllBuiltIn: false
-                include: ["pdb-max-unavailable", "pdb-min-available", "non-isolated-pod", "unset-cpu-requirements", "unset-memory-requirements"]
+                include:
+                - "host-ipc"
+                - "host-network"
+                - "host-pid"
+                - "non-isolated-pod"
+                - "pdb-max-unavailable"
+                - "pdb-min-available"
+                - "privilege-escalation-container"
+                - "privileged-container"
+                - "run-as-non-root"
+                - "unsafe-sysctls"
+                - "unset-cpu-requirements"
+                - "unset-memory-requirements"

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -54,9 +54,15 @@ func fileExists(filename string) bool {
 func (ve *validationEngine) LoadConfig(path string) error {
 	if !fileExists(path) {
 		log.Info(fmt.Sprintf("config file %s does not exist. Use default configuration", path))
-		// legacy disabled checks
-		ve.config.Checks.Exclude = getDisabledChecks()
-		ve.config.Checks.AddAllBuiltIn = true
+		// TODO - This hardcode will be removed when a ConfigMap is set by default in regular installation
+		ve.config.Checks.DoNotAutoAddDefaults = true
+		ve.config.Checks.Include = []string{
+			"pdb-max-unavailable",
+			"pdb-min-available",
+			"non-isolated-pod",
+			"unset-cpu-requirements",
+			"unset-memory-requirements",
+		}
 
 		return nil
 	}
@@ -210,39 +216,5 @@ func getIncompatibleChecks() []string {
 		"dangling-service",
 		"non-existent-service-account",
 		"non-isolated-pod",
-	}
-}
-
-// getDisabledChecks returns an array of kube-linter check names that are disabled for DVO
-// These checks are disabled as they do not have supporting Openshift documentation
-// 38 checks... 47 checks according to kube-linter website
-func getDisabledChecks() []string {
-	return []string{
-		"access-to-create-pods",
-		"access-to-secrets",
-		"cluster-admin-role-binding",
-		"default-service-account",
-		"deprecated-service-account-field",
-		"docker-sock",
-		"drop-net-raw-capability",
-		"env-var-secret",
-		"exposed-services",
-		"latest-tag",
-		"mismatching-selector",
-		"no-extensions-v1beta",
-		"no-liveness-probe",
-		"no-read-only-root-fs",
-		"no-readiness-probe",
-		"no-rolling-update-strategy",
-		"privileged-ports",
-		"read-secret-from-env-var",
-		"required-annotation-email",
-		"required-label-owner",
-		"sensitive-host-mounts",
-		"ssh-port",
-		"unsafe-proc-mount",
-		"use-namespace",
-		"wildcard-in-rules",
-		"writable-host-mount",
 	}
 }

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -57,9 +57,16 @@ func (ve *validationEngine) LoadConfig(path string) error {
 		// TODO - This hardcode will be removed when a ConfigMap is set by default in regular installation
 		ve.config.Checks.DoNotAutoAddDefaults = true
 		ve.config.Checks.Include = []string{
+			"host-ipc",
+			"host-network",
+			"host-pid",
+			"non-isolated-pod",
 			"pdb-max-unavailable",
 			"pdb-min-available",
-			"non-isolated-pod",
+			"privilege-escalation-container",
+			"privileged-container",
+			"run-as-non-root",
+			"unsafe-sysctls",
 			"unset-cpu-requirements",
 			"unset-memory-requirements",
 		}


### PR DESCRIPTION
### summary
If no custom configuration is found, the project will now whitelist the checks monitored by Rules Team by default.

### fixes
* yaml files containing default configuration data (in case they're used out of the box)
* Updated documentation with default configuration info