### PR TITLE
DVO-145: Fix parsing selectors & labels for v1.Service and others

### DIFF
--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -185,6 +185,10 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 	sort.Slice(gvks, func(i, j int) bool {
 		f := gvks[i]
 		s := gvks[j]
+		// sort resource by Kind in the same group
+		if f.Group == s.Group {
+			return f.Kind < s.Kind
+		}
 		return f.Group < s.Group
 	})
 

--- a/pkg/controller/generic_reconciler_test.go
+++ b/pkg/controller/generic_reconciler_test.go
@@ -542,6 +542,68 @@ func TestGroupAppObjects(t *testing.T) {
 				"app=A": {"deployment-A"},
 			},
 		},
+		{
+			name:      "Pods with different matching Services",
+			namespace: "test",
+			objs: []client.Object{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service-A",
+						Namespace: "test",
+					},
+					Spec: v1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "A",
+						},
+					},
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service-B",
+						Namespace: "test",
+					},
+					Spec: v1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "B",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-A",
+						Namespace: "test",
+						Labels: map[string]string{
+							"app": "A",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-B",
+						Namespace: "test",
+						Labels: map[string]string{
+							"app": "B",
+						},
+					},
+				},
+			},
+			gvks: []schema.GroupVersionKind{
+				{
+					Group:   "",
+					Kind:    "Service",
+					Version: "v1",
+				},
+				{
+					Group:   "",
+					Kind:    "Pod",
+					Version: "v1",
+				},
+			},
+			expectedNames: map[string][]string{
+				"app=A": {"pod-A", "service-A"},
+				"app=B": {"pod-B", "service-B"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/selector.go
+++ b/pkg/utils/selector.go
@@ -9,8 +9,11 @@ type manifestPath []string
 
 var (
 	// known manifest/resource paths for selector requirements
-	selectorMatchLabels         manifestPath = []string{"spec", "selector", "matchLabels"}
-	podSelectorMatchLabels      manifestPath = []string{"spec", "podSelector", "matchLabels"}
+	selectorMatchLabels    manifestPath = []string{"spec", "selector", "matchLabels"}
+	podSelectorMatchLabels manifestPath = []string{"spec", "podSelector", "matchLabels"}
+	// v1.Service, v1.ReplicationController defines the selector as map[string]string
+	// (and not as metav1.LabelSelector) in the ".spec.selector" path
+	selectorMap                 manifestPath = []string{"spec", "selector"}
 	selectorMatchExpressions    manifestPath = []string{"spec", "selector", "matchExpressions"}
 	podSelectorMatchExpressions manifestPath = []string{"spec", "podSelector", "matchExpressions"}
 )
@@ -40,7 +43,7 @@ func GetLabelSelector(object *unstructured.Unstructured) *metav1.LabelSelector {
 // readMatchLabels tries to parse known paths for the "matchLabels" attribute in the
 // unstructured object input
 func readMatchLabels(object *unstructured.Unstructured) map[string]string {
-	for _, path := range []manifestPath{selectorMatchLabels, podSelectorMatchLabels} {
+	for _, path := range []manifestPath{selectorMatchLabels, podSelectorMatchLabels, selectorMap} {
 		pathExists := pathExistsAsMap(object, path)
 		if pathExists {
 			matchLabels, _, _ := unstructured.NestedStringMap(object.Object, path...)

--- a/pkg/utils/selector_test.go
+++ b/pkg/utils/selector_test.go
@@ -201,6 +201,31 @@ func TestGetLabelSelector(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "selector defined as map[string]string with no metav1.LabelSelector",
+			unstructuredResource: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Service",
+					"apiVersion": "v1",
+					"metadata": map[string]string{
+						"name":      "test-service",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"app":         "A",
+							"environment": "production",
+						},
+					},
+				},
+			},
+			expectedLabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":         "A",
+					"environment": "production",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This fixes:
-  the sorting of GVKs - we want to sort the resources by `Kind` in the same `Group`. 
- reading the `selector` for `v1.Service` and `v1.ReplicationController` when the `selector` is defined as `map[string]string` instead of `metav1.LabelSelector` 