### PR TITLE
DVO-142: improve watcher channel comms

### DIFF
--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -143,7 +144,10 @@ func (gr *GenericReconciler) LookForConfigUpdates(ctx context.Context) {
 			gr.objectValidationCache.drain()
 			gr.validationEngine.ResetMetrics()
 
-			// TODO log new checks by name
+			gr.logger.Info(
+				"Current set of enabled checks",
+				"checks", strings.Join(gr.validationEngine.GetEnabledChecks(), ", "),
+			)
 
 		case <-ctx.Done():
 			return

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -127,8 +127,10 @@ func (gr *GenericReconciler) Start(ctx context.Context) error {
 func (gr *GenericReconciler) LookForConfigUpdates(ctx context.Context) {
 	for {
 		select {
-		case cfg := <-gr.cmWatcher.ConfigChanged():
+		case <-gr.cmWatcher.ConfigChanged():
+			cfg := gr.cmWatcher.GetConfig()
 			gr.validationEngine.SetConfig(cfg)
+
 			err := gr.validationEngine.InitRegistry()
 			if err != nil {
 				gr.logger.Error(
@@ -137,8 +139,11 @@ func (gr *GenericReconciler) LookForConfigUpdates(ctx context.Context) {
 				)
 				continue
 			}
+
 			gr.objectValidationCache.drain()
 			gr.validationEngine.ResetMetrics()
+
+			// TODO log new checks by name
 
 		case <-ctx.Done():
 			return

--- a/pkg/validations/validation_engine.go
+++ b/pkg/validations/validation_engine.go
@@ -48,6 +48,8 @@ type Interface interface {
 	InitRegistry() error
 	// DeleteMetrics deletes the Prometheus Gauge vector with the corresponding labels
 	DeleteMetrics(labels prometheus.Labels)
+	// GetEnabledChecks returns the current collection of enabled checks
+	GetEnabledChecks() []string
 	// ResetMetrics resets all the Prometheus Gauge vectors
 	ResetMetrics()
 	// SetConfig sets the kubelinter configuration
@@ -270,6 +272,11 @@ func (ve *validationEngine) ResetMetrics() {
 	for _, metric := range ve.metrics {
 		metric.Reset()
 	}
+}
+
+// GetEnabledChecks returns the current collection of enabled checks
+func (ve validationEngine) GetEnabledChecks() []string {
+	return ve.enabledChecks
 }
 
 func (ve *validationEngine) getCheckByName(name string) (config.Check, error) {


### PR DESCRIPTION
### fixes
* Fix current Watcher channel to work with an empty struct
* Add configuration property on watcher struct
* Add new method to retrieve configuration from Watcher

### improvements
* Add new method to Validation Engine (and interface) to deliver enabled checks
* Add logline with collection of enabled checks when the configuration is updated

#### new log line example 
```
INFO	reconcile	Current set of enabled checks	{"checks": "run-as-non-root, unset-memory-requirements"}
```