### PR TITLE
"stream" group of objects & process eeach namespace in a goroutine

### DIFF
--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -162,7 +162,10 @@ func (gr *GenericReconciler) reconcileEverything(ctx context.Context) error {
 	once.Do(func() {
 		apiResources, err := reconcileResourceList(gr.discovery, gr.client.Scheme())
 		if err != nil {
-			gr.logger.Error(err, "retrieving API resources to reconcile")
+			gr.logger.Error(
+				err,
+				"cannot read API resources",
+			)
 			return
 		}
 		gr.apiResources = apiResources
@@ -191,16 +194,30 @@ func (gr *GenericReconciler) reconcileEverything(ctx context.Context) error {
 	return nil
 }
 
+type unstructuredWithSelector struct {
+	unstructured *unstructured.Unstructured
+	selector     labels.Selector
+}
+
+type groupOfObjects struct {
+	objects []*unstructured.Unstructured
+	label   string
+}
+
 // groupAppObjects iterates over provided GroupVersionKind in given namespace
 // and returns map of objects grouped by their "app" label
 func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
-	namespace string, gvks []schema.GroupVersionKind) (map[string][]*unstructured.Unstructured, error) {
+	namespace string, gvks []schema.GroupVersionKind,
+	ch chan groupOfObjects) {
+	defer close(ch)
 	relatedObjects := make(map[string][]*unstructured.Unstructured)
+	labelToLabelSet := make(map[string]*labels.Set)
 
+	var objectsWithNonEmptySelector []*unstructuredWithSelector
 	// sorting GVKs is very important for getting the consistent results
 	// when trying to match the 'app' label values. We must be sure that
 	// resources from the group apps/v1 are processed between first.
-	sort.Slice(gvks, func(i, j int) bool {
+	sort.SliceStable(gvks, func(i, j int) bool {
 		f := gvks[i]
 		s := gvks[j]
 		// sort resource by Kind in the same group
@@ -209,7 +226,6 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 		}
 		return f.Group < s.Group
 	})
-
 	for _, gvk := range gvks {
 		list := unstructured.UnstructuredList{}
 		listOptions := &client.ListOptions{
@@ -220,14 +236,19 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 		for {
 
 			if err := gr.client.List(ctx, &list, listOptions); err != nil {
-				return nil, fmt.Errorf("listing %s: %w", gvk.String(), err)
+				continue
 			}
 
 			for i := range list.Items {
 				obj := &list.Items[i]
 				unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
-				processResourceLabels(obj, relatedObjects)
-				gr.processResourceSelectors(obj, relatedObjects)
+				processResourceLabels(obj, relatedObjects, labelToLabelSet)
+				sel, err := getLabelSelector(obj)
+				if err != nil || sel == labels.Nothing() {
+					continue
+				}
+				objectsWithNonEmptySelector = append(objectsWithNonEmptySelector,
+					&unstructuredWithSelector{unstructured: obj, selector: sel})
 			}
 
 			listContinue := list.GetContinue()
@@ -237,14 +258,27 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 			listOptions.Continue = listContinue
 		}
 	}
-	return relatedObjects, nil
+	for label := range relatedObjects {
+		labelsSet := labelToLabelSet[label]
+		for _, o := range objectsWithNonEmptySelector {
+			if o.selector.Matches(labelsSet) {
+				relatedObjects[label] = append(relatedObjects[label], o.unstructured)
+			}
+		}
+		ch <- groupOfObjects{label: label, objects: relatedObjects[label]}
+	}
+}
+
+func getLabelSelector(obj *unstructured.Unstructured) (labels.Selector, error) {
+	labelSelector := utils.GetLabelSelector(obj)
+	return metav1.LabelSelectorAsSelector(labelSelector)
 }
 
 // processResourceLabels reads resource labels and if the labels
 // are not empty then format them into string and put the string value
 // as key and the object as a value into "relatedObjects" map
 func processResourceLabels(obj *unstructured.Unstructured,
-	relatedObjects map[string][]*unstructured.Unstructured) {
+	relatedObjects map[string][]*unstructured.Unstructured, labelSetMapping map[string]*labels.Set) {
 
 	objLabels := utils.GetLabels(obj)
 	if len(objLabels) == 0 {
@@ -252,57 +286,35 @@ func processResourceLabels(obj *unstructured.Unstructured,
 	}
 	labelsString := labels.FormatLabels(objLabels)
 	relatedObjects[labelsString] = append(relatedObjects[labelsString], obj)
-}
-
-// processResourceSelectors reads resource selector and then tries to match
-// the selector to known labels (keys in the relatedObjects map). If a match is found then
-// the object is added to the corresponding group (values in the relatedObjects map).
-func (gr *GenericReconciler) processResourceSelectors(obj *unstructured.Unstructured,
-	relatedObjects map[string][]*unstructured.Unstructured) {
-	labelSelector := utils.GetLabelSelector(obj)
-	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-	if err != nil {
-		gr.logger.Error(err, "cannot convert label selector for object", obj.GetKind(), obj.GetName())
-		return
-	}
-
-	if selector == labels.Nothing() {
-		return
-	}
-
-	for k := range relatedObjects {
-		labelsSet, err := labels.ConvertSelectorToLabelsMap(k)
-		if err != nil {
-			gr.logger.Error(err, "cannot convert selector to labels map for", obj.GetKind(), obj.GetName())
-			continue
-		}
-		if selector.Matches(labelsSet) {
-			relatedObjects[k] = append(relatedObjects[k], obj)
-		}
-	}
+	labelSetMapping[labelsString] = &objLabels
 }
 
 func (gr *GenericReconciler) processNamespacedResources(
 	ctx context.Context, gvks []schema.GroupVersionKind, namespaces *[]namespace) error {
 
+	var wg sync.WaitGroup
+	wg.Add(len(*namespaces))
 	for _, ns := range *namespaces {
-		relatedObjects, err := gr.groupAppObjects(ctx, ns.name, gvks)
-		if err != nil {
-			return err
-		}
-		for label, objects := range relatedObjects {
-			gr.logger.Info("reconcileNamespaceResources",
-				"Reconciling group of", len(objects), "objects with labels", label,
-				"in the namespace", ns.name)
-			err := gr.reconcileGroupOfObjects(ctx, objects, ns.name)
-			if err != nil {
-				return fmt.Errorf(
-					"reconciling related objects with labels '%s': %w", label, err,
-				)
-			}
-		}
-	}
+		namespace := ns.name
+		go func() {
+			ch := make(chan groupOfObjects)
+			go gr.groupAppObjects(ctx, namespace, gvks, ch)
 
+			for groupOfObjects := range ch {
+				gr.logger.Info("reconcileNamespaceResources",
+					"Reconciling group of", len(groupOfObjects.objects),
+					"objects with labels", groupOfObjects.label,
+					"in the namespace", namespace)
+				err := gr.reconcileGroupOfObjects(ctx, groupOfObjects.objects, namespace)
+				if err != nil {
+					gr.logger.Error(err, "error reconciling group of ",
+						len(groupOfObjects.objects), "objects ", "in the namespace", namespace)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 	return nil
 }
 

--- a/pkg/controller/generic_reconciler_test.go
+++ b/pkg/controller/generic_reconciler_test.go
@@ -610,10 +610,10 @@ func TestGroupAppObjects(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// create testing reconciler
-			gr, err := createTestReconciler(nil, tt.objs)
+			gr, err := createTestReconciler(nil, tt.gvks, tt.objs)
 			assert.NoError(t, err)
 			ch := make(chan groupOfObjects)
-			go gr.groupAppObjects(context.Background(), tt.namespace, tt.gvks, ch)
+			go gr.groupAppObjects(context.Background(), tt.namespace, ch)
 
 			resultMap := make(map[string][]string)
 			for groupOfObjects := range ch {
@@ -691,7 +691,7 @@ func TestUnstructuredToTyped(t *testing.T) {
 			err := v1.AddToScheme(tt.scheme)
 			assert.NoError(t, err)
 
-			gr, err := createTestReconciler(tt.scheme, nil)
+			gr, err := createTestReconciler(tt.scheme, nil, nil)
 			assert.NoError(t, err)
 			o, err := gr.unstructuredToTyped(tt.u)
 			if tt.expectedError == nil {
@@ -741,11 +741,8 @@ func TestGetNamespacedResourcesGVK(t *testing.T) {
 
 	for _, ut := range unitTests {
 		t.Run(ut.name, func(t *testing.T) {
-			// Given
-			gr := GenericReconciler{}
-
 			// When
-			test := gr.getNamespacedResourcesGVK(ut.arg)
+			test := getNamespacedResourcesGVK(ut.arg)
 
 			// Assert
 			assert.Equal(t, ut.result, test)
@@ -866,12 +863,12 @@ func TestProcessNamespacedResources(t *testing.T) {
 			err = policyv1.AddToScheme(sch)
 			assert.NoError(t, err)
 
-			testReconciler, err := createTestReconciler(sch, tt.objects)
+			testReconciler, err := createTestReconciler(sch, tt.gvks, tt.objects)
 			assert.NoError(t, err)
 
 			// set some namespaces to be watched
 			testReconciler.watchNamespaces.setCache(tt.namespaces)
-			err = testReconciler.processNamespacedResources(context.Background(), tt.gvks, tt.namespaces)
+			err = testReconciler.processNamespacedResources(context.Background(), tt.namespaces)
 			assert.NoError(t, err)
 			for _, o := range tt.objects {
 				vr, ok := testReconciler.objectValidationCache.retrieve(o)
@@ -985,7 +982,7 @@ func TestHandleResourceDeletions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testReconciler, err := createTestReconciler(nil, nil)
+			testReconciler, err := createTestReconciler(nil, nil, nil)
 			assert.NoError(t, err)
 			testReconciler.watchNamespaces.setCache(&tt.testNamespaces) // nolint:gosec
 
@@ -1020,12 +1017,13 @@ func TestHandleResourceDeletions(t *testing.T) {
 
 func TestListLimit(t *testing.T) {
 	os.Setenv(EnvResorucesPerListQuery, "2")
-	testReconciler, err := createTestReconciler(runtime.NewScheme(), nil)
+	testReconciler, err := createTestReconciler(runtime.NewScheme(), nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), testReconciler.listLimit)
 }
 
-func createTestReconciler(scheme *runtime.Scheme, objects []client.Object) (*GenericReconciler, error) {
+func createTestReconciler(scheme *runtime.Scheme, gvks []schema.GroupVersionKind,
+	objects []client.Object) (*GenericReconciler, error) {
 	cliBuilder := clifake.NewClientBuilder()
 	if scheme != nil {
 		cliBuilder.WithScheme(scheme)
@@ -1040,5 +1038,10 @@ func createTestReconciler(scheme *runtime.Scheme, objects []client.Object) (*Gen
 	if err != nil {
 		return nil, err
 	}
-	return NewGenericReconciler(client, cli.Discovery(), &configmap.Watcher{}, ve)
+	testGenericReconciler, err := NewGenericReconciler(client, cli.Discovery(), &configmap.Watcher{}, ve)
+	if err != nil {
+		return nil, err
+	}
+	testGenericReconciler.resourceGVKs = gvks
+	return testGenericReconciler, nil
 }

--- a/pkg/validations/validation_engine_test.go
+++ b/pkg/validations/validation_engine_test.go
@@ -258,7 +258,7 @@ func TestRunValidationsForObjects(t *testing.T) {
 				customCheckName, metricValue, tt.initialExpectedMetricValue)
 
 			// Problem resolved
-			deployment.Spec.Replicas = &tt.updatedReplicaCount
+			deployment.Spec.Replicas = &tt.updatedReplicaCount // nolint:gosec
 			_, err = ve.RunValidationsForObjects([]client.Object{deployment}, request.NamespaceUID)
 			assert.NoError(t, err, "Error running validations")
 			// Metric with label combination should be successfully cleared because problem was resolved.
@@ -272,7 +272,7 @@ func TestRunValidationsForObjects(t *testing.T) {
 				customCheckMetricVal, tt.updatedExpectedMetricValue)
 
 			if tt.runAdditionalValidation {
-				deployment.Spec.Replicas = &tt.initialReplicaCount
+				deployment.Spec.Replicas = &tt.initialReplicaCount // nolint:gosec
 				_, err = ve.RunValidationsForObjects([]client.Object{deployment}, request.NamespaceUID)
 				assert.NoError(t, err, "Error running validations")
 


### PR DESCRIPTION
This PR add more streamed and concurrent processing to the reconciler and requires thorough review and extensive testing. Changes are:

- send each group of related objects to the kube-linter validation via channel
- process each namespace in its own goroutine
- sort the known groupVersionKinds only once 