### PR TITLE
style: fixing gosec implicit memory for tests

### DIFF
--- a/pkg/controller/generic_reconciler_test.go
+++ b/pkg/controller/generic_reconciler_test.go
@@ -978,7 +978,8 @@ func TestHandleResourceDeletions(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, testCase := range tests {
+		tt := testCase
 		t.Run(tt.name, func(t *testing.T) {
 			testReconciler, err := createTestReconciler(nil, nil)
 			assert.NoError(t, err)

--- a/pkg/validations/validation_engine_test.go
+++ b/pkg/validations/validation_engine_test.go
@@ -223,7 +223,8 @@ func TestRunValidationsForObjects(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, testCase := range tests {
+		tt := testCase
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := make(map[string]*prometheus.GaugeVec)
 			ve, err := newValidationEngine("test-resources/config-with-custom-check.yaml", metrics)


### PR DESCRIPTION
Fixes this message:

```
pkg/validations/validation_engine_test.go:261:31: G601: Implicit memory aliasing in for loop. (gosec)
                        deployment.Spec.Replicas = &tt.updatedReplicaCount
                                                   ^
pkg/validations/validation_engine_test.go:275:32: G601: Implicit memory aliasing in for loop. (gosec)
                                deployment.Spec.Replicas = &tt.initialReplicaCount
                                                           ^
```