### PR TITLE
DVO-173: Update deployments exclude patterns

### DIFF
--- a/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -73,7 +73,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: deployment-validation-operator
                 - name: NAMESPACE_IGNORE_PATTERN
-                  value: openshift.*|kube-.+|default|dedicated-admin
+                  value: openshift.*|kube-.+|open-cluster-management-.*|default|dedicated-admin
                 - name: RESOURCES_PER_LIST_QUERY
                   value: "5"
                 - name: VALIDATION_CHECK_INTERVAL

--- a/deploy/openshift/deployment-validation-operator-olm.yaml
+++ b/deploy/openshift/deployment-validation-operator-olm.yaml
@@ -97,7 +97,7 @@ parameters:
   description: OLM subscription channel
   required: true
 - name: NAMESPACE_IGNORE_PATTERN
-  value: "^(openshift.*|kube-.*|default|dedicated-admin|redhat-.*|acm|addon-dba-operator|codeready-.*|prow)$"
+  value: "^(openshift.*|kube-.*|open-cluster-management-.*|default|dedicated-admin|redhat-.*|acm|addon-dba-operator|codeready-.*|prow)$"
   displayName: Namespace ignore pattern
   description: A golang regex to ignore checks from matching patterns
 - name: SOURCE

--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -77,7 +77,7 @@ spec:
         - name: OPERATOR_NAME
           value: "deployment-validation-operator"
         - name: NAMESPACE_IGNORE_PATTERN
-          value: "openshift.*|kube-.+|default|dedicated-admin"
+          value: "openshift.*|kube-.+|open-cluster-management-.*|default|dedicated-admin"
         - name: RESOURCES_PER_LIST_QUERY
           value: "5"
         - name: VALIDATION_CHECK_INTERVAL

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -94,7 +94,7 @@ objects:
             config:
               env:
               - name: "NAMESPACE_IGNORE_PATTERN"
-                value: "^(openshift.*|kube-.*|default|dedicated-admin|redhat-.*|acm|addon-dba-operator|codeready-.*|prow)$"
+                value: "^(openshift.*|kube-.*|open-cluster-management-.*|default|dedicated-admin|redhat-.*|acm|addon-dba-operator|codeready-.*|prow)$"
             name: deployment-validation-operator
             source: deployment-validation-operator-catalog
             sourceNamespace: openshift-deployment-validation-operator


### PR DESCRIPTION
#### summary
* Exclude resources whose namespaces are based on `open-cluster-management` prefix