### PR TITLE
DVO-178: remove status from the validated objects

### DIFF
--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -244,6 +244,7 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 			for i := range list.Items {
 				obj := &list.Items[i]
 				unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
+				unstructured.RemoveNestedField(obj.Object, "status")
 				processResourceLabels(obj, relatedObjects, labelToLabelSet)
 				sel, err := getLabelSelector(obj)
 				if err != nil || sel == labels.Nothing() {


### PR DESCRIPTION
kubelinter validations don't seem to require 'status' attribute of the objects