### PR TITLE
cannot "stream" group of related objects

### DIFF
--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -238,7 +238,7 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 			Version: "v1",
 			Kind:    "project",
 		})
-		gr.client.Get(ctx, ok, &ns, &client.GetOptions{
+		err := gr.client.Get(ctx, ok, &ns, &client.GetOptions{
 			Raw: &metav1.GetOptions{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "project",
@@ -246,6 +246,9 @@ func (gr *GenericReconciler) groupAppObjects(ctx context.Context,
 				},
 			},
 		})
+		if err != nil {
+			klog.Info("============= ERROR getting namespace ", err)
+		}
 		actualUID := string(ns.GetUID())
 		if namespace.uid != actualUID {
 			klog.Infof("============================== HIT THE PROBLEM %s %s", namespace.uid, actualUID)


### PR DESCRIPTION
The problem is that when a namespace is deleted in the right time (when reading the data from the channel for the group of related objects) then it led to registering false positive metric (some resoure in non-existing namespace) that can be never deleted. 