### PR TITLE
DVO-205: (chore) replace golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
   enable:
   - gofmt
   - goimports
-  - golint
+  - revive
   - govet
   - misspell
   - unused
@@ -18,10 +18,6 @@ linters:
   - staticcheck
 
 linters-settings:
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0
-
   lll:
     line-length: 120
     tab-width: 8

--- a/internal/testing/client.go
+++ b/internal/testing/client.go
@@ -27,7 +27,7 @@ func (c *TestClient) Create(ctx context.Context, obj client.Object, opts ...Requ
 	}
 }
 
-func (c *TestClient) Update(ctx context.Context, obj client.Object, opts ...RequestOption) {
+func (c *TestClient) Update(ctx context.Context, obj client.Object, _ ...RequestOption) {
 	gomega.ExpectWithOffset(1, c.client.Update(ctx, obj)).Should(gomega.Succeed())
 }
 

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -171,6 +171,7 @@ func (s *Server) Start(ctx context.Context) error {
 	errCh := make(chan error)
 	drain := func() {
 		for range errCh {
+			continue
 		}
 	}
 


### PR DESCRIPTION
This PR replaces the deprecated `golint` with `revive` and fixes some code style issues reported by it.