### PR TITLE
DVO-209: CPU leak fix

### DIFF
--- a/pkg/controller/const.go
+++ b/pkg/controller/const.go
@@ -11,6 +11,10 @@ const (
 	// number of resource instances for any kubernetes resource
 	defaultListLimit = 5
 
+	// default time (in seconds) to skip the loop in the generic reconciler
+	// if there are no namespaces to validate in the cluster
+	defaultNoNamespacesElapseTime = 10
+
 	// EnvKubeClientQPS overrides defaultKubeClientQPS
 	EnvKubeClientQPS string = "KUBECLIENT_QPS"
 

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -123,10 +123,11 @@ func (gr *GenericReconciler) Start(ctx context.Context) error {
 			gr.watchNamespaces.resetCache()
 			if namespaces, err := gr.watchNamespaces.getWatchNamespaces(ctx, gr.client); err != nil {
 				gr.logger.Error(err, "getting watched namespaces")
+				continue
 
 			} else if namespaces == nil || len(*namespaces) == 0 {
 				gr.logger.Info("No namespaces to validate, skipping loop")
-				time.Sleep(10 * time.Second)
+				time.Sleep(defaultNoNamespacesElapseTime * time.Second)
 				continue
 			}
 

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -124,7 +124,7 @@ func (gr *GenericReconciler) Start(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("getting watched namespaces: %w", err)
 			}
-			if namespaces == nil {
+			if namespaces == nil || len(*namespaces) == 0 {
 				time.Sleep(10 * time.Second)
 			}
 

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -122,10 +122,15 @@ func (gr *GenericReconciler) Start(ctx context.Context) error {
 			gr.watchNamespaces.resetCache()
 			namespaces, err := gr.watchNamespaces.getWatchNamespaces(ctx, gr.client)
 			if err != nil {
-				return fmt.Errorf("getting watched namespaces: %w", err)
+				// return fmt.Errorf("getting watched namespaces: %w", err)
+				gr.logger.Error(err, "getting watched namespaces")
 			}
 			if namespaces == nil || len(*namespaces) == 0 {
+				gr.logger.Info("No namespaces to validate, skipping loop")
 				time.Sleep(10 * time.Second)
+				continue
+				//logger
+				//continue
 			}
 
 			if err := gr.reconcileEverything(ctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -119,18 +119,15 @@ func (gr *GenericReconciler) Start(ctx context.Context) error {
 		default:
 			gr.logger.Info("Reconciliation loop has started")
 
+			// Skips validation if no valid namespaces in the cluster. Avoids CPU overusage
 			gr.watchNamespaces.resetCache()
-			namespaces, err := gr.watchNamespaces.getWatchNamespaces(ctx, gr.client)
-			if err != nil {
-				// return fmt.Errorf("getting watched namespaces: %w", err)
+			if namespaces, err := gr.watchNamespaces.getWatchNamespaces(ctx, gr.client); err != nil {
 				gr.logger.Error(err, "getting watched namespaces")
-			}
-			if namespaces == nil || len(*namespaces) == 0 {
+
+			} else if namespaces == nil || len(*namespaces) == 0 {
 				gr.logger.Info("No namespaces to validate, skipping loop")
 				time.Sleep(10 * time.Second)
 				continue
-				//logger
-				//continue
 			}
 
 			if err := gr.reconcileEverything(ctx); err != nil && !errors.Is(err, context.Canceled) {
@@ -193,7 +190,6 @@ func (gr *GenericReconciler) reconcileEverything(ctx context.Context) error {
 			"Kind", resource.Kind)
 	}
 
-	//gr.watchNamespaces.resetCache()
 	namespaces, err := gr.watchNamespaces.getWatchNamespaces(ctx, gr.client)
 	if err != nil {
 		return fmt.Errorf("getting watched namespaces: %w", err)


### PR DESCRIPTION
### summary

When DVO is installed in a cluster with no namespaces to validate, the code in reconcile packages loops so fast that GC does not have time to address everything. This apparently causes CPU usage to grow up to the set limit.

This fix checks the namespaces to validate before triggering the logic in the `reconcileEverything` function. If there is no namespace to validate, it just waits a bit and skips the loop.