### PR TITLE
use the existing VALIDATION_CHECK_INTERVAL env var and run kube-linte…

### DIFF
--- a/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ spec:
                 - name: RESOURCES_PER_LIST_QUERY
                   value: "5"
                 - name: VALIDATION_CHECK_INTERVAL
-                  value: "2"
+                  value: "2m"
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:

--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -80,7 +80,7 @@ spec:
         - name: RESOURCES_PER_LIST_QUERY
           value: "5"
         - name: VALIDATION_CHECK_INTERVAL
-          value: "2"
+          value: "2m"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,6 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/containerd v1.7.11 h1:lfGKw3eU35sjV0aG2eYZTiwFEY1pCzxdzicHP3SZILw=
-github.com/containerd/containerd v1.7.11/go.mod h1:5UluHxHTX2rdvYuZ5OJTC5m/KJNs0Zs9wVoJm9zf5ZE=
 github.com/containerd/containerd v1.7.12 h1:+KQsnv4VnzyxWcfO9mlxxELaoztsDEjOuCMPAuPqgU0=
 github.com/containerd/containerd v1.7.12/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
 github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG023MDM=
@@ -869,8 +867,6 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
 gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
-helm.sh/helm/v3 v3.14.2 h1:V71fv+NGZv0icBlr+in1MJXuUIHCiPG1hW9gEBISTIA=
-helm.sh/helm/v3 v3.14.2/go.mod h1:2itvvDv2WSZXTllknfQo6j7u3VVgMAvm8POCDgYH424=
 helm.sh/helm/v3 v3.14.3 h1:HmvRJlwyyt9HjgmAuxHbHv3PhMz9ir/XNWHyXfmnOP4=
 helm.sh/helm/v3 v3.14.3/go.mod h1:v6myVbyseSBJTzhmeE39UcPLNv6cQK6qss3dvgAySaE=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/controller/const.go
+++ b/pkg/controller/const.go
@@ -11,10 +11,6 @@ const (
 	// number of resource instances for any kubernetes resource
 	defaultListLimit = 5
 
-	// default time (in seconds) to skip the loop in the generic reconciler
-	// if there are no namespaces to validate in the cluster
-	defaultNoNamespacesElapseTime = 10
-
 	// EnvKubeClientQPS overrides defaultKubeClientQPS
 	EnvKubeClientQPS string = "KUBECLIENT_QPS"
 
@@ -24,4 +20,7 @@ const (
 	// EnvNamespaceIgnorePattern sets the pattern for ignoring namespaces from the list of namespaces
 	// that are in the validate list of this operator
 	EnvNamespaceIgnorePattern string = "NAMESPACE_IGNORE_PATTERN"
+
+	// EnvValidationCheckInterval sets the frequency of the kube-linter check validations in minutes
+	EnvValidationCheckInterval string = "VALIDATION_CHECK_INTERVAL"
 )


### PR DESCRIPTION
…r validations accordingly

This reverts commit dd287c8364b3e9789bf8e182873dcc21f7acfdf2.