### PR TITLE
DVO-224 trying to fix failing build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,6 @@ e2e-test:
 
 # We are early adopters of the OPM build/push process. Remove this
 # override once boilerplate uses that path by default.
-build-push: opm-build-push ;
+build-push: 
+	$(eval python := /usr/bin/python3)
+	opm-build-push ;


### PR DESCRIPTION
https://ci.int.devshift.net/view/deployment-validation-operator/job/app-sre-deployment-validation-operator-gh-build-master is failing because of 
```
16:00:17 boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh: line 246: python: command not found
```
this is an attempt to fix or at least workaround