### PR TITLE
OSD-24739 / DVO-223: Making sure DVO is deployed/updated on all hosted clusters

### DIFF
--- a/hack/olm-registry/hypershift-template.yaml
+++ b/hack/olm-registry/hypershift-template.yaml
@@ -196,9 +196,6 @@ objects:
             name: placement-deployment-validation-operator
             namespace: openshift-acm-policies
           spec:
-            clusterConditions:
-            - status: "True"
-              type: ManagedClusterConditionAvailable
             clusterSelector:
               matchExpressions:
                 - key: hypershift.open-cluster-management.io/hosted-cluster


### PR DESCRIPTION
Deployment on Hypershift hosted clusters is inspired by the deployment of the metrics-forwarder config.

As you can see, the `PlacementRule` has evolved for this config:
https://github.com/openshift/hypershift-dataplane-metrics-forwarder/pull/52/files
(more details in [OSD-21462](https://issues.redhat.com/browse/OSD-21462))

We should no longer ignore `ManagedCluster`s (objects at service cluster level) for which the `ManagedClusterConditionAvailable` condition is not "true"