### PR TITLE
DVO-228: Move registry login to script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ docker-publish: quay-login docker-build docker-push
 ## This target is run by the master branch Jenkins Job
 .PHONY: build-push
 build-push: docker-publish
-	CONTAINER_ENGINE="${CONTAINER_ENGINE}" \
+	@echo "## Building bundle and catalog images..."
+	@(CONTAINER_ENGINE="${CONTAINER_ENGINE}" \
 	CONTAINER_ENGINE_CONFIG_DIR="${CONTAINER_ENGINE_CONFIG_DIR}" \
 	CURRENT_COMMIT="${CURRENT_COMMIT}" \
 	OLM_BUNDLE_IMAGE="${OLM_BUNDLE_IMAGE}" \
@@ -102,4 +103,7 @@ build-push: docker-publish
 	OPERATOR_VERSION="${OPERATOR_VERSION}" \
 	OPERATOR_IMAGE="${OPERATOR_IMAGE}" \
 	OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG}" \
-		build/build_opm_catalog.sh
+	IMAGE_REGISTRY=${IMAGE_REGISTRY} \
+	REGISTRY_USER="${REGISTRY_USER}" \
+	REGISTRY_TOKEN="${REGISTRY_TOKEN}" \
+		build/build_opm_catalog.sh)

--- a/build/build_opm_catalog.sh
+++ b/build/build_opm_catalog.sh
@@ -40,6 +40,10 @@ function precheck_required_files() {
     return 0
 }
 
+function login_image_registry() {
+    ${CONTAINER_ENGINE} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" ${IMAGE_REGISTRY}
+}
+
 function prepare_temporary_folders() {
     BASE_FOLDER=$(mktemp -d --suffix "-$(basename "$0")")
     DIR_BUNDLE=$(mktemp -d -p "$BASE_FOLDER" bundle.XXXX)
@@ -87,6 +91,10 @@ function set_previous_operator_version() {
 }
 
 function setup_environment() {
+    log "Login Image registry"
+    login_image_registry
+    log "  Successfully login to $IMAGE_REGISTRY"
+
     log "Generating temporary folders to contain artifacts"
     prepare_temporary_folders
     log "  base path: $BASE_FOLDER"
@@ -221,7 +229,7 @@ function tag_and_push_images() {
 
 function main() {
     log "Building $OPERATOR_NAME version $OPERATOR_VERSION"
-    
+
     precheck_required_files || return 1
 
     setup_environment


### PR DESCRIPTION
### summary

* Script scope was using wrong set of credentials to log in to image registry
* Sent env vars with the creds from the Makefile
* Set the command as hidden to avoid leaking creds in the job's output