### PR TITLE
NO-JIRA: Remove deprecated reference to JAVA dependency

### DIFF
--- a/.tekton/deployment-validation-operator-push.yaml
+++ b/.tekton/deployment-validation-operator-push.yaml
@@ -130,9 +130,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:


### PR DESCRIPTION
#### summary

Konflux CI pipeline deployment-validation-operator on-push is failing. This fix should work removing a deprecated dependency. This was not saw on the previous Update references' PR from Konflux.