### PR TITLE
SDCICD-1436: set securityContextConfig restricted

### DIFF
--- a/hack/olm-registry/hypershift-template.yaml
+++ b/hack/olm-registry/hypershift-template.yaml
@@ -85,6 +85,8 @@ objects:
                             image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
                             displayName: Deployment Validation Operator
                             publisher: Red Hat
+                            grpcPodConfig:
+                              securityContextConfig: restricted
                       - complianceType: MustHave
                         objectDefinition:
                           apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
This is causing a PodSecurityViolation leading to DVO not running on HCP clusters

```
Status:
  Message:  couldn't ensure registry server - error ensuring pod: : error creating new pod: deployment-validation-operator-catalog-: pods "deployment-validation-operator-catalog-7wq6g" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "registry-server" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "registry-server" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "registry-server" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "registry-server" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  Reason:   RegistryServerError
```

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/60085/rehearse-60085-periodic-ci-openshift-release-master-nightly-4.19-e2e-rosa-sts-hypershift-ovn/1884402470344462336