### PR TITLE
NO-JIRA: Bump Golang to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/app-sre/deployment-validation-operator
 
-go 1.23.6
+go 1.22.9
+
+toolchain go1.23.6
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/app-sre/deployment-validation-operator
 
-go 1.22.4
-
-toolchain go1.22.5
+go 1.23.6
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344


### PR DESCRIPTION
#### summary

Bump Golang version now that the builder image was upgraded