### PR TITLE
Update the Golang version of .ci-operator.yaml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-8-release-golang-1.22-openshift-4.17
+  tag: rhel-8-release-golang-1.23-openshift-4.19


### PR DESCRIPTION
This PR aims to fix the error from CI
`go: golang.org/x/sys@v0.31.0 requires go >= 1.23.0 (running go 1.22.9; GOTOOLCHAIN=local)
make: *** [Makefile:30: go-mod-update] Error 1
{"component":"entrypoint","error":"wrapped process failed: exit status `
So we need to update the Golang version inside `.ci-operator.yaml` to `1.23`

Reference link: https://redhat-internal.slack.com/archives/G019KPS1S6R/p1745256764181379