### PR TITLE
DVO-213: Add ImageDigestMirrorSet links

### DIFF
--- a/.tekton/deployment-validation-operator-fbc-pull-request.yaml
+++ b/.tekton/deployment-validation-operator-fbc-pull-request.yaml
@@ -242,6 +242,31 @@ spec:
         operator: in
         values:
         - "true"
+    - name: fbc-fips-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check:0.1@sha256:03e9fd8c7c7fdcb8c965333fa7b2ea83e75da766f5ecd92cbc02ae4a92b2e247
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      workspaces:
+      - name: workspace
+        workspace: workspace
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL

--- a/.tekton/deployment-validation-operator-fbc-push.yaml
+++ b/.tekton/deployment-validation-operator-fbc-push.yaml
@@ -238,6 +238,31 @@ spec:
         operator: in
         values:
         - "true"
+    - name: fbc-fips-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check:0.1@sha256:03e9fd8c7c7fdcb8c965333fa7b2ea83e75da766f5ecd92cbc02ae4a92b2e247
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      workspaces:
+      - name: workspace
+        workspace: workspace
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageDigestMirrorSet
+metadata:
+  name: staging-mirror-set
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:cb4a68ebedba10bbd504fb271b3b7cc52d01ed13557dcb9604059f1ba98717d1
+      source: registry.stage.redhat.io/dvo/deployment-validation-rhel8-operator

--- a/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Application Runtime, Monitoring, Security
     certified: "false"
-    containerImage: quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator
+    containerImage: registry.stage.redhat.io/dvo/deployment-validation-rhel8-operator
     createdAt: 2024-11-27T00:00:00Z
     description: The deployment validation operator
     operators.openshift.io/valid-subscription: "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]"
@@ -104,7 +104,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:cb4a68ebedba10bbd504fb271b3b7cc52d01ed13557dcb9604059f1ba98717d1
+                image: registry.stage.redhat.io/dvo/deployment-validation-rhel8-operator
                 imagePullPolicy: Always
                 name: deployment-validation-operator
                 ports:

--- a/konflux-ci/staging-release.yaml
+++ b/konflux-ci/staging-release.yaml
@@ -5,11 +5,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
- name: staging-release-test-pxmtl
+ name: staging-release-snapshot-0425-01
  namespace: dvo-obsint-tenant
 spec:
  releasePlan: release-plan-staging
- snapshot: deployment-validation-operator-pxmtl
+ snapshot: staging-snapshot-0425-01
  data:
   releaseNotes:
    topic: Test Release

--- a/konflux-ci/staging-snapshot.yaml
+++ b/konflux-ci/staging-snapshot.yaml
@@ -12,7 +12,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: manual-release-snapshot
+  name: staging-snapshot-0425-01
   namespace: dvo-obsint-tenant
   labels:
     test.appstudio.openshift.io/type: override 
@@ -20,14 +20,14 @@ spec:
   application: deployment-validation-operator
   components:
     - name: deployment-validation-operator
-      containerImage: quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:0e312d3edc28b931b721eb5ddc59feea4f9141707925224f6b936401b479b4b1
+      containerImage: quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:63883be503162382f850c20dd3f034b69ea6ab6eb04c497e4254e17a09e99587
       source:
         git:
           url: https://github.com/app-sre/deployment-validation-operator
-          revision: b861deee00c1afc3ba91ffac56932d24870358c9
+          revision: ea6bc934725a0653d6460cee294e98d66ed146cb
     - name: deployment-validation-operator-bundle
-      containerImage: quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator-bundle@sha256:a96eb0ba48f11f163d243cead0519dd58de726e64963ed5e5ddcc19f253ba201
+      containerImage: quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator-bundle@sha256:05fcd25a14821f3259f7940874e5a78e62404603ea7910a5c379a726fbed91ea
       source:
         git:
           url: https://github.com/app-sre/deployment-validation-operator
-          revision: b861deee00c1afc3ba91ffac56932d24870358c9
+          revision: ea6bc934725a0653d6460cee294e98d66ed146cb


### PR DESCRIPTION
#### summary

Add ImageDigestMirrorSet manifest to link Konflux images with future registry images' links

#### misc

* Some refactoring on the manifests for Snapshot and Release
* Added missing FBC task for FIPS on Konflux pipeline