### PR TITLE
Add missing versoin and release labels (for Konflux)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -29,6 +29,8 @@ LABEL name="deployment-validation-operator" \
       io.k8s.display-name="Deployment Validation Operator" \
       io.k8s.description="Deployment Validation Operator for OpenShift" \
       io.openshift.tags="dvo,deployment-validation-operator"
+      version="0.7" \
+      release="10" \
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 


### PR DESCRIPTION
#### summary

Missing labels were added to the Dockerfile image. This change shouldn't modify the image, but it will allow Konflux pipelines to extract this information directly from the labels instead of configuring it manually.