### PR TITLE
DVO-283: Update minimum Golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/app-sre/deployment-validation-operator
 
-go 1.23.0
+go 1.23.9
 
 toolchain go1.24.2
 


### PR DESCRIPTION
#### summary

Fixes CVE-2025-22871 with a Golang version +1.23.8