### PR TITLE
DVO-285: Fix Konflux pipeline for the FBC for OCP 4.18

### DIFF
--- a/.tekton/dvo-fbc-ocp4-18-pull-request.yaml
+++ b/.tekton/dvo-fbc-ocp4-18-pull-request.yaml
@@ -104,7 +104,7 @@ spec:
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
-    - default: []
+    - default: ["OCP_V=v4.18"]
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
       type: array

--- a/.tekton/dvo-fbc-ocp4-18-push.yaml
+++ b/.tekton/dvo-fbc-ocp4-18-push.yaml
@@ -100,7 +100,7 @@ spec:
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
-    - default: []
+    - default: ["OCP_V=v4.18"]
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
       type: array

--- a/konflux-ci/fbc/catalog.Dockerfile
+++ b/konflux-ci/fbc/catalog.Dockerfile
@@ -1,14 +1,17 @@
+ARG OCP_V=latest
+
 # The builder image is expected to contain
 # /bin/opm (with serve subcommand)
-FROM registry.redhat.io/openshift4/ose-operator-registry as builder
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:$OCP_V as builder
 
 # Copy FBC root into image at /configs and pre-populate serve cache
 ADD catalog /configs
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
-FROM registry.redhat.io/openshift4/ose-operator-registry
+ARG OCP_V
 # The base image is expected to contain
 # /bin/opm (with serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:$OCP_V
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
#### summary

* The catalog's Dockerfile was fixed to accept build-arg parameters. Specifically, it was changed so that the image used would be a concrete OCP version.
* Fixed the tekton files for the Konflux pipeline for this FBC (OCP 4.18)