### PR TITLE
NO-JIRA: Fix images typos from dependabot

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.23.9-2 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.23.9-2.1750813114 AS builder
 
 USER root
 
@@ -9,7 +9,7 @@ ENV FIPS_ENABLED=1
 RUN make go-build
 
 # This image has to match RHEL version from the CI or will cause some side-effects on glibc (and possibly others)
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295.1749680713.1749680713
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295.1749680713
 
 ENV OPERATOR=/usr/local/bin/deployment-validation-operator \
     USER_UID=1001 \


### PR DESCRIPTION
#### summary

Apparently `dependabot` introduces by error a duplication on the version release for the images we use on the Dockerfile

#### misc

Merging here #529 