### PR TITLE
NO-JIRA: Upgrade release version for the operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -30,7 +30,7 @@ LABEL name="deployment-validation-operator" \
       io.k8s.description="Deployment Validation Operator for OpenShift" \
       io.openshift.tags="dvo,deployment-validation-operator" \
       version="0.7" \
-      release="10"
+      release="11"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 


### PR DESCRIPTION
#### summary

The operator image generates snapshots separately from the bundle image on Konflux. We need this to be upgraded previously to merge bundle upgrades in #535 