### PR TITLE
DVO-295: Add arm64 to the build-platforms param

### DIFF
--- a/.tekton/fbc-ocp4-15-pull-request.yaml
+++ b/.tekton/fbc-ocp4-15-pull-request.yaml
@@ -31,6 +31,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-15-push.yaml
+++ b/.tekton/fbc-ocp4-15-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-16-pull-request.yaml
+++ b/.tekton/fbc-ocp4-16-pull-request.yaml
@@ -31,6 +31,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-16-push.yaml
+++ b/.tekton/fbc-ocp4-16-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-17-pull-request.yaml
+++ b/.tekton/fbc-ocp4-17-pull-request.yaml
@@ -31,6 +31,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-17-push.yaml
+++ b/.tekton/fbc-ocp4-17-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-18-pull-request.yaml
+++ b/.tekton/fbc-ocp4-18-pull-request.yaml
@@ -31,6 +31,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-18-push.yaml
+++ b/.tekton/fbc-ocp4-18-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-19-pull-request.yaml
+++ b/.tekton/fbc-ocp4-19-pull-request.yaml
@@ -31,6 +31,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/fbc-ocp4-19-push.yaml
+++ b/.tekton/fbc-ocp4-19-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context


### PR DESCRIPTION
#### summary

Fixing the pipelines of the FBCs for all OCP versions with the new soon-to-be supported arch (ARM64)