### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for deployment-validation-operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,13 +22,14 @@ COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 
 # These labels are needed in order to release on Konflux
-LABEL name="deployment-validation-operator" \
+LABEL name="dvo/deployment-validation-rhel8-operator" \
       summary="Deployment Validation Operator for OpenShift" \
       description="Deployment Validation Operator for OpenShift" \
       com.redhat.component="deployment-validation-operator-container" \
       io.k8s.display-name="Deployment Validation Operator" \
       io.k8s.description="Deployment Validation Operator for OpenShift" \
       io.openshift.tags="dvo,deployment-validation-operator" \
+      cpe="cpe:/a:redhat:deployment_validator_operator:0.7::el8" \
       version="0.7" \
       release="12"
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
