### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for deployment-validation-operator-bundle

### DIFF
--- a/konflux-ci/bundle/bundle.Dockerfile
+++ b/konflux-ci/bundle/bundle.Dockerfile
@@ -4,7 +4,8 @@ COPY ./manifests /manifests
 COPY ./metadata /metadata
 
 LABEL com.redhat.component="deployment-validation-operator-bundle-container" \
-      name="app-sre/deployment-validation-operator-bundle" \
+      name="dvo/deployment-validation-operator-bundle" \
+      cpe="cpe:/a:redhat:deployment_validator_operator:0.7::el8" \
       version="0.7" \
       release="12" \
       distribution-scope="private" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
