### PR TITLE
DVO-297: Rollback misconfig of kube-linter checks for managed clusters

### DIFF
--- a/hack/olm-registry/hypershift-template.yaml
+++ b/hack/olm-registry/hypershift-template.yaml
@@ -177,21 +177,36 @@ objects:
                           data:
                             deployment-validation-operator-config.yaml: |-
                               checks:
-                                doNotAutoAddDefaults: true
-                                addAllBuiltIn: false
-                                include:
-                                - "host-ipc"
-                                - "host-network"
-                                - "host-pid"
-                                - "non-isolated-pod"
-                                - "pdb-max-unavailable"
-                                - "pdb-min-available"
-                                - "privilege-escalation-container"
-                                - "privileged-container"
-                                - "run-as-non-root"
-                                - "unsafe-sysctls"
-                                - "unset-cpu-requirements"
-                                - "unset-memory-requirements"
+                                doNotAutoAddDefaults: false
+                                addAllBuiltIn: true
+
+                                exclude:
+                                - "access-to-create-pods"
+                                - "access-to-secrets"
+                                - "cluster-admin-role-binding"
+                                - "default-service-account"
+                                - "deprecated-service-account-field"
+                                - "docker-sock"
+                                - "drop-net-raw-capability"
+                                - "env-var-secret"
+                                - "exposed-services"
+                                - "latest-tag"
+                                - "mismatching-selector"
+                                - "no-extensions-v1beta"
+                                - "no-liveness-probe"
+                                - "no-read-only-root-fs"
+                                - "no-readiness-probe"
+                                - "no-rolling-update-strategy"
+                                - "privileged-ports"
+                                - "read-secret-from-env-var"
+                                - "required-annotation-email"
+                                - "required-label-owner"
+                                - "sensitive-host-mounts"
+                                - "ssh-port"
+                                - "unsafe-proc-mount"
+                                - "use-namespace"
+                                - "wildcard-in-rules"
+                                - "writable-host-mount"
         - apiVersion: apps.open-cluster-management.io/v1
           kind: PlacementRule
           metadata:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -151,18 +151,33 @@ objects:
           data:
             deployment-validation-operator-config.yaml: |-
               checks:
-                doNotAutoAddDefaults: true
-                addAllBuiltIn: false
-                include:
-                - "host-ipc"
-                - "host-network"
-                - "host-pid"
-                - "non-isolated-pod"
-                - "pdb-max-unavailable"
-                - "pdb-min-available"
-                - "privilege-escalation-container"
-                - "privileged-container"
-                - "run-as-non-root"
-                - "unsafe-sysctls"
-                - "unset-cpu-requirements"
-                - "unset-memory-requirements"
+                doNotAutoAddDefaults: false
+                addAllBuiltIn: true
+
+                exclude:
+                - "access-to-create-pods"
+                - "access-to-secrets"
+                - "cluster-admin-role-binding"
+                - "default-service-account"
+                - "deprecated-service-account-field"
+                - "docker-sock"
+                - "drop-net-raw-capability"
+                - "env-var-secret"
+                - "exposed-services"
+                - "latest-tag"
+                - "mismatching-selector"
+                - "no-extensions-v1beta"
+                - "no-liveness-probe"
+                - "no-read-only-root-fs"
+                - "no-readiness-probe"
+                - "no-rolling-update-strategy"
+                - "privileged-ports"
+                - "read-secret-from-env-var"
+                - "required-annotation-email"
+                - "required-label-owner"
+                - "sensitive-host-mounts"
+                - "ssh-port"
+                - "unsafe-proc-mount"
+                - "use-namespace"
+                - "wildcard-in-rules"
+                - "writable-host-mount"


### PR DESCRIPTION
#### summary

Fixed the default Kube-Linter checks in the ConfigMap for managed clusters and hypershift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled built‑in validation checks by default for broader out‑of‑the‑box coverage.
- Chores
  - Migrated from an include-based to an exclude-based validation policy configuration.
  - Added and consolidated exclusions for specific host, security, and resource checks to fine-tune enforcement.
  - Updated operator configuration templates to reflect the new defaults and exclusions.
- Tests
  - None
- Documentation
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->