### PR TITLE
chore(SLSRE-645): remove DVO from Service and Management Clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -47,6 +47,11 @@ objects:
           - key: hive.openshift.io/version-major-minor-patch
             operator: NotIn
             values: ["4.11.0", "4.11.1", "4.11.2", "4.11.3", "4.11.4", "4.11.5", "4.11.6", "4.11.7", "4.11.8", "4.11.9"]
+          - key: ext-hypershift.openshift.io/cluster-type
+            operator: NotIn
+            values:
+              - management-cluster
+              - service-cluster
       resourceApplyMode: Sync
       resources:
         - apiVersion: v1


### PR DESCRIPTION
### Summary

Removes DVO deployments from ROSA Service and Management Clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster deployment selector configuration to exclude specific cluster types from deployment targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->