### PR TITLE
DVO-364: Update memory limits to avoid OOM

### DIFF
--- a/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -109,10 +109,10 @@ spec:
                   timeoutSeconds: 3
                 resources:
                   limits:
-                    memory: 400Mi
+                    memory: 600Mi
                   requests:
                     cpu: 50m
-                    memory: 200Mi
+                    memory: 400Mi
                 securityContext:
                   readOnlyRootFilesystem: true
                 volumeMounts:

--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -57,7 +57,7 @@ spec:
             memory: "400Mi"
             cpu: "50m"
           limits:
-            memory: "400Mi"
+            memory: "600Mi"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -113,10 +113,10 @@ spec:
                   protocol: TCP
                 resources:
                   limits:
-                    memory: 400Mi
+                    memory: 600Mi
                   requests:
                     cpu: 50m
-                    memory: 200Mi
+                    memory: 400Mi
                 securityContext:
                   readOnlyRootFilesystem: true
                 volumeMounts:


### PR DESCRIPTION
#### summary
Some clusters were identified in which the pod running the DVO was getting OOM killed. It was not possible to replicate the issue because the test cluster size was insufficient. However, given the progression of memory consumption as the number of deployments increases, it's plausible that the DVO requires more memory in such cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory resource configuration for the deployment-validation-operator with increased limits and requests across multiple deployment manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->