### PR TITLE
DVO-416: [release-0.7.15] Update the operator image digest

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   imageDigestMirrors:
     - mirrors:
-        - quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:9b7dc41f779c51c44ab83bdc184b03b75db5f31c141f7b67d028842560edbaca
-      source: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:9b7dc41f779c51c44ab83bdc184b03b75db5f31c141f7b67d028842560edbaca
+        - quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
+      source: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe

--- a/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Application Runtime, Monitoring, Security
     certified: "false"
-    containerImage: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:9b7dc41f779c51c44ab83bdc184b03b75db5f31c141f7b67d028842560edbaca
+    containerImage: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
     createdAt: 2024-11-27T00:00:00Z
     description: The deployment validation operator
     operators.openshift.io/valid-subscription: "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]"
@@ -104,7 +104,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:9b7dc41f779c51c44ab83bdc184b03b75db5f31c141f7b67d028842560edbaca
+                image: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
                 imagePullPolicy: Always
                 name: deployment-validation-operator
                 ports:
@@ -173,7 +173,7 @@ spec:
   - name: repository
     url: https://github.com/app-sre/deployment-validation-operator
   - name: containerImage
-    url: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:9b7dc41f779c51c44ab83bdc184b03b75db5f31c141f7b67d028842560edbaca
+    url: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
   maintainers:
   - name: Red Hat
     email: dvo-owners@redhat.com


### PR DESCRIPTION
#### summary

Update the operator image digest. This links the image to the mirrorset, as well as to the references to it in the bundle CSV.

#### tracker

https://issues.redhat.com/browse/DVO-416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment-validation-operator container image references across all deployment specifications and image mirroring configurations to point to a newly validated container image version. These coordinated updates ensure the operator maintains a consistent image across all deployment components, cluster service definitions, and image registry mirror infrastructure throughout the entire system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->