### PR TITLE
[CCXDEV-16390] [Proposal] Add KinD scripts for running DVO e2e tests locally

### DIFF
--- a/kind/README.md
+++ b/kind/README.md
@@ -1,0 +1,66 @@
+# DVO E2E Tests on KinD
+
+Run the DVO e2e test suite on a local [KinD](https://kind.sigs.k8s.io/) cluster
+instead of a full OpenShift cluster.
+
+## Prerequisites
+
+- [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- Docker or Podman
+- Python 3 with PyYAML (`pip install pyyaml`)
+
+## Usage
+
+```bash
+# 1. Create the cluster and deploy DVO
+./kind/setup.sh
+
+# 2. Run the tests
+./kind/run-tests.sh
+
+# 3. Tear down the cluster
+./kind/teardown.sh
+```
+
+### What `setup.sh` does
+
+1. Creates a KinD cluster with a NodePort mapping (port 8383) for metrics access
+2. Builds the DVO operator image from source
+3. Pulls and loads the httpd test image into the cluster
+4. Deploys the DVO operator using the upstream manifests with on-the-fly patches
+   (removes node affinity/tolerations, sets `imagePullPolicy: IfNotPresent`)
+5. Waits for the operator to be ready
+
+### What `run-tests.sh` does
+
+Runs the test suite from the
+`quay.io/redhatqe/deployment-validation-operator-tests:latest` container image.
+Override with `--image <image>` or the `DVO_TEST_IMAGE` env var.
+
+Extra pytest arguments can be passed after `--`:
+
+```bash
+./kind/run-tests.sh -- -k test_configmap_deletion --tb=short
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `KIND_CLUSTER_NAME` | `dvo-test` | KinD cluster name |
+| `CONTAINER_ENGINE` | auto-detected | `docker` or `podman` |
+| `DVO_TEST_IMAGE` | `quay.io/redhatqe/deployment-validation-operator-tests:latest` | Test container image |
+| `HTTPD_TEST_IMAGE` | `registry.access.redhat.com/ubi8/httpd-24:latest` | httpd image for test deployments |
+
+## How it works
+
+The DVO operator uses only standard Kubernetes APIs at runtime — no CRDs, no
+OpenShift controllers. The adaptations for KinD are minimal:
+
+- **Metrics access**: OpenShift Routes are replaced with a NodePort service.
+  The `DVO_METRICS_URL` env var tells the tests to use it directly.
+- **httpd image**: The test deployment image is configurable via
+  `HTTPD_TEST_IMAGE` instead of pulling from the OpenShift internal registry.
+- **Operator manifests**: Node selectors, tolerations, and affinity rules are
+  stripped since KinD runs a single node.

--- a/kind/config.yaml
+++ b/kind/config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30383
+        hostPort: 8383
+        protocol: TCP

--- a/kind/run-tests.sh
+++ b/kind/run-tests.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-dvo-test}"
+TEST_IMAGE="${DVO_TEST_IMAGE:-quay.io/redhatqe/deployment-validation-operator-tests:latest}"
+HTTPD_IMAGE="${HTTPD_TEST_IMAGE:-registry.access.redhat.com/ubi8/httpd-24:latest}"
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-$(command -v docker || command -v podman)}"
+DVO_METRICS_URL="http://localhost:8383"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--image <image>] [-- <pytest args>]
+
+Options:
+  --image IMG  Test container image (default: ${TEST_IMAGE})
+  --           Pass remaining arguments to pytest
+
+Environment variables:
+  DVO_TEST_IMAGE      Test container image
+  KIND_CLUSTER_NAME   KinD cluster name (default: dvo-test)
+  CONTAINER_ENGINE    Container engine (default: docker or podman)
+EOF
+    exit 1
+}
+
+PYTEST_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image)
+            TEST_IMAGE="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            PYTEST_ARGS=("$@")
+            break
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            PYTEST_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ ${#PYTEST_ARGS[@]} -eq 0 ]]; then
+    PYTEST_ARGS=(-v -m "not ui")
+fi
+
+KUBECONFIG_TMP="$(mktemp)"
+kind get kubeconfig --name "${CLUSTER_NAME}" > "${KUBECONFIG_TMP}"
+chmod 644 "${KUBECONFIG_TMP}"
+
+echo "==> Running tests from image: ${TEST_IMAGE}"
+echo "    Metrics: ${DVO_METRICS_URL}"
+
+${CONTAINER_ENGINE} run --rm \
+    --network host \
+    -v "${KUBECONFIG_TMP}:/tmp/kubeconfig:Z" \
+    -e KUBECONFIG=/tmp/kubeconfig \
+    -e DVO_METRICS_URL="${DVO_METRICS_URL}" \
+    -e HTTPD_TEST_IMAGE="${HTTPD_IMAGE}" \
+    "${TEST_IMAGE}" \
+    pytest.sh "${PYTEST_ARGS[@]}"
+
+rm -f "${KUBECONFIG_TMP}"

--- a/kind/setup.sh
+++ b/kind/setup.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-dvo-test}"
+DVO_IMAGE="localhost/dvo-operator:latest"
+DVO_NAMESPACE="openshift-operators"
+HTTPD_IMAGE="${HTTPD_TEST_IMAGE:-registry.access.redhat.com/ubi8/httpd-24:latest}"
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-$(command -v docker || command -v podman)}"
+
+echo "==> Using container engine: ${CONTAINER_ENGINE}"
+
+# 1. Delete existing cluster if present
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+    echo "==> Deleting existing KinD cluster '${CLUSTER_NAME}'..."
+    kind delete cluster --name "${CLUSTER_NAME}"
+fi
+
+# 2. Create KinD cluster
+echo "==> Creating KinD cluster '${CLUSTER_NAME}'..."
+kind create cluster \
+    --name "${CLUSTER_NAME}" \
+    --config "${SCRIPT_DIR}/config.yaml" \
+    --wait 60s
+
+# 3. Build the DVO operator image
+echo "==> Building DVO operator image..."
+cd "${OPERATOR_DIR}"
+${CONTAINER_ENGINE} build -f build/Dockerfile -t "${DVO_IMAGE}" .
+
+# 4. Load operator image into KinD
+# Using save + image-archive instead of "kind load docker-image" because the
+# latter can't find images in Podman's store (https://github.com/kubernetes-sigs/kind/issues/2038)
+echo "==> Loading DVO operator image into KinD..."
+${CONTAINER_ENGINE} save "${DVO_IMAGE}" | kind load image-archive /dev/stdin --name "${CLUSTER_NAME}"
+
+# 5. Pull and load httpd image into KinD
+echo "==> Preparing httpd image..."
+${CONTAINER_ENGINE} pull "${HTTPD_IMAGE}"
+${CONTAINER_ENGINE} save "${HTTPD_IMAGE}" | kind load image-archive /dev/stdin --name "${CLUSTER_NAME}"
+
+# 6. Create namespace
+echo "==> Creating ${DVO_NAMESPACE} namespace..."
+kubectl create namespace "${DVO_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+# 7. Deploy DVO manifests
+DEPLOY_DIR="${OPERATOR_DIR}/deploy/openshift"
+echo "==> Deploying DVO resources..."
+
+kubectl apply -f "${DEPLOY_DIR}/service-account.yaml" -n "${DVO_NAMESPACE}"
+kubectl apply -f "${DEPLOY_DIR}/cluster-role.yaml"
+
+# The upstream ClusterRoleBinding and RoleBinding reference the ServiceAccount in
+# namespace "deployment-validation-operator". In KinD we deploy to "openshift-operators"
+# to match what OLM does in production. Patch the SA namespace reference on-the-fly.
+sed "s/namespace: deployment-validation-operator/namespace: ${DVO_NAMESPACE}/g" \
+    "${DEPLOY_DIR}/cluster-role-binding.yaml" | kubectl apply -f -
+
+kubectl apply -f "${DEPLOY_DIR}/role.yaml" -n "${DVO_NAMESPACE}"
+sed "s/namespace: deployment-validation-operator/namespace: ${DVO_NAMESPACE}/g" \
+    "${DEPLOY_DIR}/role-binding.yaml" | kubectl apply -f -
+
+kubectl apply -f "${DEPLOY_DIR}/configmap.yaml" -n "${DVO_NAMESPACE}"
+
+# Deploy service as NodePort
+echo "==> Deploying DVO Service (NodePort)..."
+kubectl apply -f "${DEPLOY_DIR}/service.yaml" -n "${DVO_NAMESPACE}"
+kubectl patch svc deployment-validation-operator-metrics \
+    -n "${DVO_NAMESPACE}" \
+    --type='json' \
+    -p='[
+        {"op": "replace", "path": "/spec/type", "value": "NodePort"},
+        {"op": "add", "path": "/spec/ports/0/nodePort", "value": 30383}
+    ]'
+
+# Deploy operator with KinD-compatible spec (single apply, no rolling update issues)
+echo "==> Deploying DVO operator (patched for KinD)..."
+sed -e "s|quay.io/deployment-validation-operator/dv-operator:latest|${DVO_IMAGE}|" \
+    -e "s|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|" \
+    -e 's|value: "2m"|value: "10s"|' \
+    "${DEPLOY_DIR}/operator.yaml" | \
+    python3 -c "
+import sys, yaml
+doc = yaml.safe_load(sys.stdin)
+spec = doc['spec']['template']['spec']
+spec.pop('nodeSelector', None)
+spec.pop('tolerations', None)
+spec.pop('affinity', None)
+yaml.dump(doc, sys.stdout, default_flow_style=False)
+" | kubectl apply -f - -n "${DVO_NAMESPACE}"
+
+# 8. Wait for DVO pod readiness
+echo "==> Waiting for DVO operator to be ready..."
+kubectl rollout status deployment/deployment-validation-operator \
+    -n "${DVO_NAMESPACE}" \
+    --timeout=120s
+
+echo ""
+echo "==> KinD cluster '${CLUSTER_NAME}' is ready!"
+echo "    Metrics endpoint: http://localhost:8383/metrics"
+echo ""
+echo "    Run tests with: ./kind/run-tests.sh"

--- a/kind/teardown.sh
+++ b/kind/teardown.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-dvo-test}"
+
+echo "==> Deleting KinD cluster '${CLUSTER_NAME}'..."
+kind delete cluster --name "${CLUSTER_NAME}"
+echo "==> Done."


### PR DESCRIPTION
## Summary

Add scripts to create a KinD cluster, deploy the DVO operator, and run the
existing e2e test suite without requiring a full OpenShift cluster.

- `kind/config.yaml`: KinD cluster config with NodePort mapping for metrics
- `kind/setup.sh`: creates cluster, builds and loads images, deploys DVO
- `kind/run-tests.sh`: runs tests from the test container image
- `kind/teardown.sh`: deletes the cluster
- `kind/README.md`: usage and configuration documentation

Usage:
```bash
./kind/setup.sh
./kind/run-tests.sh
./kind/teardown.sh
```

## Dependencies

This MR requires the corresponding changes in:
- **ccx-ocp-testlib**: Fix Kubernetes compatibility issues for KinD testing (see [MR](https://gitlab.cee.redhat.com/ccx/ccx-ocp-testlib/-/merge_requests/154))
- **deployment-validation-operator-tests**: Support running tests on vanilla Kubernetes (see [MR](https://gitlab.cee.redhat.com/ccx/deployment-validation-operator-tests/-/merge_requests/63))

## How to test locally

The test container image (`quay.io/redhatqe/deployment-validation-operator-tests:latest`)
does not include the dependency changes yet. To test end-to-end, build a local
test image that overlays the unreleased changes.

### 1. Clone the repos side by side

```
parent/
├── ccx-ocp-testlib/                       # with the KinD compatibility branch
├── deployment-validation-operator/        # this MR
└── deployment-validation-operator-tests/  # with the vanilla K8s support branch
```

### 2. Build a local test image

A `kind/Dockerfile.tests` is provided for this purpose:

```dockerfile
FROM quay.io/redhatqe/deployment-validation-operator-tests:latest

USER 0

COPY ccx-ocp-testlib /tmp/ccx-ocp-testlib
COPY deployment-validation-operator-tests/tests /insights-operator-tests/tests
COPY deployment-validation-operator-tests/shared /insights-operator-tests/shared

RUN pip install --no-cache-dir -e /tmp/ccx-ocp-testlib

USER 1001
```

Build from the parent directory so all repos are in the build context:

```bash
cd parent/
podman build -f deployment-validation-operator/kind/Dockerfile.tests \
    -t localhost/dvo-tests:dev .
```

### 3. Run the setup and tests

```bash
cd deployment-validation-operator/
./kind/setup.sh
./kind/run-tests.sh --image localhost/dvo-tests:dev
```

### 4. Clean up

```bash
./kind/teardown.sh
```


---

Assisted-by: Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for running the test suite on a local KinD cluster with prerequisites and configurable options.

* **Chores**
  * Added automation scripts for KinD cluster provisioning, test execution, and cleanup with environment variable support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->