### PR TITLE
CCXDEV-16373: Add SKILL file to identify existent CVEs

### DIFF
--- a/.skills/cve-monitoring/SKILL.md
+++ b/.skills/cve-monitoring/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: cve-monitoring
+description: >-
+  Identify any vulnerabilities in the production image and check if an issue has already been
+  opened in the project's Jira space to address it.
+  Report any missing CVEs and the libraries/images they affect.
+---
+
+# cve-monitoring
+
+## Follow this procedure
+
+1. **Query public CVE sources**:
+    For the catalog image of the project: `registry.redhat.io/dvo/deployment-validation-rhel8-operator:latest`, check for known CVEs using authoritative sources:
+        - Red Hat Security Data API (`https://access.redhat.com/hydra/rest/securitydata/`)
+        - OSV (`https://api.osv.dev/v1/query`)
+        - NVD (via CPE or package identifier)
+2. **Look up severity externally**:
+    CVSS score - use `WebSearch` for the CVE ID on NVD (e.g., `CVE-2026-33231 NVD`) to get the severity rating
+3. **Cross-reference with existing opened issues**:
+    Use the following JQL to find unresolved issues in the Jira space:
+    ```JQL
+        project = "DVO" AND resolution = Unresolved AND issuetype = Vulnerability
+    ```
+    Compare the discovered CVEs in the step 1 against the unresolved DVO issues to identify any that lack a corresponding `Vulnerability` issue (filter by CVE ID in issue summary or labels).
+5. **Report gaps**:
+    For each unreported CVE:
+        - Find the library or the image impacted by it checking `go.mod` and `build/Dockerfile` files.
+        - Record the CVE ID, affected package/version, CVSS score, and a brief description.
+
+## Output
+
+A list of unreported CVEs for review.


### PR DESCRIPTION
#### summary

A new SKILL file has been added to ASDLC. This file will be used to detect any existing CVEs in the production image that may still be undetected. It reports on these gaps, as well as the affected libraries and the severity. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new CVE monitoring skill guide documenting procedures for vulnerability identification, severity evaluation, cross-referencing with existing issues, and reporting unreported CVEs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->