### PR TITLE
WIP SREP-3553 Use community-operators catalog instead of custom CatalogSo…

### DIFF
--- a/hack/olm-registry/hypershift-template.yaml
+++ b/hack/olm-registry/hypershift-template.yaml
@@ -75,22 +75,6 @@ objects:
                               openshift.io/cluster-monitoring: "true"
                       - complianceType: MustHave
                         objectDefinition:
-                          apiVersion: operators.coreos.com/v1alpha1
-                          kind: CatalogSource
-                          metadata:
-                            name: deployment-validation-operator-catalog
-                            namespace: openshift-deployment-validation-operator
-                          spec:
-                            sourceType: grpc
-                            image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-                            displayName: Deployment Validation Operator
-                            publisher: Red Hat
-                            grpcPodConfig:
-                              securityContextConfig: restricted
-                              nodeSelector:
-                                kubernetes.io/arch: amd64
-                      - complianceType: MustHave
-                        objectDefinition:
                           apiVersion: operators.coreos.com/v1
                           kind: OperatorGroup
                           metadata:
@@ -120,8 +104,8 @@ objects:
                               - name: "NAMESPACE_IGNORE_PATTERN"
                                 value: "^(openshift.*|kube-.*|default|dedicated-admin|redhat-.*|acm|addon-dba-operator|codeready-.*|prow)$"
                             name: deployment-validation-operator
-                            source: deployment-validation-operator-catalog
-                            sourceNamespace: openshift-deployment-validation-operator
+                            source: community-operators
+                            sourceNamespace: openshift-marketplace
                       - complianceType: MustHave
                         objectDefinition:
                           apiVersion: networking.k8s.io/v1
@@ -139,21 +123,6 @@ objects:
                               - Ingress
                       - complianceType: MustHave
                         objectDefinition:
-                          apiVersion: networking.k8s.io/v1
-                          kind: NetworkPolicy
-                          metadata:
-                            name: allow-from-openshift-olm
-                            namespace: openshift-deployment-validation-operator
-                          spec:
-                            ingress: 
-                              - {}
-                            podSelector:
-                              matchLabels:
-                                olm.catalogSource: deployment-validation-operator-catalog
-                            policyTypes:
-                              - Ingress
-                      - complianceType: MustHave
-                        objectDefinition:                      
                           apiVersion: v1
                           kind: Service
                           metadata:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -60,25 +60,6 @@ objects:
             name: openshift-deployment-validation-operator
             labels:
               openshift.io/cluster-monitoring: "true"
-        - apiVersion: operators.coreos.com/v1alpha1
-          kind: CatalogSource
-          metadata:
-            name: deployment-validation-operator-catalog
-            namespace: openshift-deployment-validation-operator
-          spec:
-            sourceType: grpc
-            grpcPodConfig:
-              securityContextConfig: restricted
-              nodeSelector:
-                node-role.kubernetes.io: infra
-                kubernetes.io/arch: amd64
-              tolerations:
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/infra
-                operator: Exists
-            image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-            displayName: Deployment Validation Operator
-            publisher: Red Hat
         - apiVersion: operators.coreos.com/v1
           kind: OperatorGroup
           metadata:
@@ -104,8 +85,8 @@ objects:
               - name: "NAMESPACE_IGNORE_PATTERN"
                 value: "^(openshift.*|kube-.*|open-cluster-management-.*|default|dedicated-admin|redhat-.*|acm|addon-dba-operator|codeready-.*|prow)$"
             name: deployment-validation-operator
-            source: deployment-validation-operator-catalog
-            sourceNamespace: openshift-deployment-validation-operator
+            source: community-operators
+            sourceNamespace: openshift-marketplace
         - apiVersion: networking.k8s.io/v1
           kind: NetworkPolicy
           metadata:


### PR DESCRIPTION
…urce

https://redhat.atlassian.net/browse/SREP-3553

Remove the custom CatalogSource that deployed images from quay.io/redhat-user-workloads which are not approved for production clusters (images have not passed Konflux Conforma compliance tests).

Instead, point the Subscription to the community-operators catalog in openshift-marketplace, which already contains DVO.

Changes:
- olm-artifacts-template.yaml: Remove CatalogSource, update Subscription source to community-operators
- hypershift-template.yaml: Remove CatalogSource and associated NetworkPolicy, update Subscription source to community-operators

The REGISTRY_IMG/IMAGE_DIGEST parameters are kept for now as IMAGE_TAG is still used for the SelectorSyncSet gitHash label.