### PR TITLE
Fix managed-clusters bundle CSV for Conforma compliance

### DIFF
--- a/konflux-ci/managed-clusters/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/konflux-ci/managed-clusters/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     capabilities: Basic Install
     categories: Application Runtime, Monitoring, Security
     certified: 'false'
-    containerImage: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
+    containerImage: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:88437b35173fe2e8a4d9f148ec17c754bee4df3f723b3a5676955eef4f363d31
     createdAt: '2026-05-15T13:13:48Z'
     description: The deployment validation operator
     repository: https://github.com/app-sre/deployment-validation-operator
@@ -21,6 +21,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
   name: deployment-validation-operator.v0.7.15
 spec:
   description: |
@@ -104,7 +105,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
+                image: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:88437b35173fe2e8a4d9f148ec17c754bee4df3f723b3a5676955eef4f363d31
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -187,7 +188,7 @@ spec:
   - name: repository
     url: https://github.com/app-sre/deployment-validation-operator
   - name: containerImage
-    url: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
+    url: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:88437b35173fe2e8a4d9f148ec17c754bee4df3f723b3a5676955eef4f363d31
   maturity: alpha
   provider:
     name: Red Hat


### PR DESCRIPTION
## Summary
- Add missing `operators.openshift.io/valid-subscription` annotation
- Update operator image reference to `quay.io/redhat-services-prod/openshift/dvo-operator`

## Problem
The managed-clusters bundle release was failing Conforma checks:
1. `olm.subscriptions_annotation_format` - The valid-subscription annotation was missing
2. `olm.unmapped_references` - The operator image at `registry.redhat.io` was not accessible to Conforma during the `quay.io/redhat-services-prod` release pipeline

## Solution
- Added the required subscription annotation
- Updated all operator image references to point to `quay.io/redhat-services-prod/openshift/dvo-operator@sha256:88437b35173fe2e8a4d9f148ec17c754bee4df3f723b3a5676955eef4f363d31`

This digest was obtained after releasing the operator via the new `dvo-managed-clusters-operator` RPA merged in konflux-release-data.

## Test Plan
- [ ] Merge this PR
- [ ] Wait for Konflux to rebuild managed-clusters-bundle
- [ ] Trigger bundle release - should pass Conforma checks

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment validation operator container image registry reference.
  * Updated operator subscription support configuration for OpenShift Container Platform and OpenShift Platform Plus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->