### PR TITLE
DVO-483: [release-0.7.16] Update the operator image digest

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   imageDigestMirrors:
     - mirrors:
-        - quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
-      source: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
+        - quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
+      source: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd

--- a/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Application Runtime, Monitoring, Security
     certified: "false"
-    containerImage: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
+    containerImage: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
     createdAt: 2024-11-27T00:00:00Z
     description: The deployment validation operator
     operators.openshift.io/valid-subscription: "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]"
@@ -104,7 +104,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
+                image: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
                 imagePullPolicy: Always
                 name: deployment-validation-operator
                 ports:
@@ -173,7 +173,7 @@ spec:
   - name: repository
     url: https://github.com/app-sre/deployment-validation-operator
   - name: containerImage
-    url: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:3c014410a11ea662e4762e3f4181238b5b0fd062887c5d0f32e0551c7d68e1fe
+    url: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
   maintainers:
   - name: Red Hat
     email: dvo-owners@redhat.com

--- a/konflux-ci/managed-clusters/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/konflux-ci/managed-clusters/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     capabilities: Basic Install
     categories: Application Runtime, Monitoring, Security
     certified: 'false'
-    containerImage: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:88437b35173fe2e8a4d9f148ec17c754bee4df3f723b3a5676955eef4f363d31
+    containerImage: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
     createdAt: '2026-05-15T13:13:48Z'
     description: The deployment validation operator
     repository: https://github.com/app-sre/deployment-validation-operator
@@ -105,7 +105,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:88437b35173fe2e8a4d9f148ec17c754bee4df3f723b3a5676955eef4f363d31
+                image: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -188,7 +188,7 @@ spec:
   - name: repository
     url: https://github.com/app-sre/deployment-validation-operator
   - name: containerImage
-    url: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:88437b35173fe2e8a4d9f148ec17c754bee4df3f723b3a5676955eef4f363d31
+    url: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
   maturity: alpha
   provider:
     name: Red Hat


### PR DESCRIPTION
#### summary

Update the operator image digest. This links the image to the mirrorset, as well as to the references to it in the bundle CSV.

#### tracker

https://issues.redhat.com/browse/DVO-483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Deployment Validation Operator container image to a newer verified digest.
  * Synchronized image references across deployment metadata, runtime configuration, and image mirror settings.
  * No operator version, behavior, or configuration changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->