### PR TITLE
DVO-485: Fix base image to UBI 9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1785155581 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1785791459 AS builder
 
 USER root
 
@@ -8,8 +8,7 @@ WORKDIR /workdir
 ENV FIPS_ENABLED=1
 RUN make go-build
 
-# This image has to match RHEL version from the CI or will cause some side-effects on glibc (and possibly others)
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1783932150
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785777232
 
 ENV OPERATOR=/usr/local/bin/deployment-validation-operator \
     USER_UID=1001 \


### PR DESCRIPTION
#### summary

Updating the base images to UBI 9 to comply with security updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s underlying build and runtime environments to the latest UBI9-based images.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->