### PR TITLE
DVO-491: Add new Dockerfile for OCP5 versions

### DIFF
--- a/.tekton/fbc-ocp5-0-pull-request.yaml
+++ b/.tekton/fbc-ocp5-0-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
     - linux/x86_64
     - linux/arm64
   - name: dockerfile
-    value: catalog.Dockerfile
+    value: catalog.ocp5.Dockerfile
   - name: path-context
     value: konflux-ci/fbc
   pipelineSpec:

--- a/.tekton/fbc-ocp5-0-push.yaml
+++ b/.tekton/fbc-ocp5-0-push.yaml
@@ -29,7 +29,7 @@ spec:
     - linux/x86_64
     - linux/arm64
   - name: dockerfile
-    value: catalog.Dockerfile
+    value: catalog.ocp5.Dockerfile
   - name: path-context
     value: konflux-ci/fbc
   pipelineSpec:

--- a/konflux-ci/fbc/catalog.ocp5.Dockerfile
+++ b/konflux-ci/fbc/catalog.ocp5.Dockerfile
@@ -1,0 +1,25 @@
+ARG OCP_V=latest
+
+# The builder image is expected to contain
+# /bin/opm (with serve subcommand)
+FROM registry.redhat.io/openshift5/ose-operator-registry-rhel9:$OCP_V as builder
+
+# Copy FBC root into image at /configs and pre-populate serve cache
+ADD bundle.object/catalog /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+ARG OCP_V
+# The base image is expected to contain
+# /bin/opm (with serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift5/ose-operator-registry-rhel9:$OCP_V
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+
+# Set FBC-specific label for the location of the FBC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs


### PR DESCRIPTION
#### summary

Added a new containerfile for the upcoming OpenShift versions.

Fixed the Konflux pipelines for version 5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building and serving OpenShift 5 file-based catalog images.
  - Catalog images now include preloaded serving data for improved startup readiness.

- **Bug Fixes**
  - Updated pull-request and release pipelines to use the OpenShift 5 catalog configuration, ensuring the correct catalog is built and published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->