### PR TITLE
DVO-500: [release-0.7.17] Update the operator image digest

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   imageDigestMirrors:
     - mirrors:
-        - quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
-      source: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
+        - quay.io/redhat-user-workloads/dvo-obsint-tenant/deployment-validation-operator/deployment-validation-operator@sha256:29732da3a7857f5a7acaa9e24edd92a4fe9dc5a53c0f5f98f6a3f3627913d379
+      source: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:29732da3a7857f5a7acaa9e24edd92a4fe9dc5a53c0f5f98f6a3f3627913d379

--- a/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/konflux-ci/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Application Runtime, Monitoring, Security
     certified: "false"
-    containerImage: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
+    containerImage: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:29732da3a7857f5a7acaa9e24edd92a4fe9dc5a53c0f5f98f6a3f3627913d379
     createdAt: 2024-11-27T00:00:00Z
     description: The deployment validation operator
     operators.openshift.io/valid-subscription: "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]"
@@ -104,7 +104,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
+                image: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:29732da3a7857f5a7acaa9e24edd92a4fe9dc5a53c0f5f98f6a3f3627913d379
                 imagePullPolicy: Always
                 name: deployment-validation-operator
                 ports:
@@ -173,7 +173,7 @@ spec:
   - name: repository
     url: https://github.com/app-sre/deployment-validation-operator
   - name: containerImage
-    url: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
+    url: registry.redhat.io/dvo/deployment-validation-rhel8-operator@sha256:29732da3a7857f5a7acaa9e24edd92a4fe9dc5a53c0f5f98f6a3f3627913d379
   maintainers:
   - name: Red Hat
     email: dvo-owners@redhat.com

--- a/konflux-ci/managed-clusters/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
+++ b/konflux-ci/managed-clusters/bundle/manifests/deployment-validation-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     capabilities: Basic Install
     categories: Application Runtime, Monitoring, Security
     certified: 'false'
-    containerImage: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
+    containerImage: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:29732da3a7857f5a7acaa9e24edd92a4fe9dc5a53c0f5f98f6a3f3627913d379
     createdAt: '2026-05-15T13:13:48Z'
     description: The deployment validation operator
     repository: https://github.com/app-sre/deployment-validation-operator
@@ -105,7 +105,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
+                image: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:29732da3a7857f5a7acaa9e24edd92a4fe9dc5a53c0f5f98f6a3f3627913d379
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -188,7 +188,7 @@ spec:
   - name: repository
     url: https://github.com/app-sre/deployment-validation-operator
   - name: containerImage
-    url: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:099b3af427b8e1eb44765283a640446c3225151baa06eed789623206151a60cd
+    url: quay.io/redhat-services-prod/openshift/dvo-operator@sha256:29732da3a7857f5a7acaa9e24edd92a4fe9dc5a53c0f5f98f6a3f3627913d379
   maturity: alpha
   provider:
     name: Red Hat


### PR DESCRIPTION
#### summary

Update the operator image digest. This links the image to the mirrorset, as well as to the references to it in the bundles' CSV.
#### tracker

https://issues.redhat.com/browse/DVO-500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Deployment Validation Operator image references to a newer verified image.
  - Applied the updated image consistently across mirrored deployments and managed cluster installation manifests.
  - No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->