### PR TITLE
DVO-500: [release-0.7.17] Update release payloads

### DIFF
--- a/konflux-ci/cli-manifests/release-payloads/prod-release-0.7.16-fbc.yaml
+++ b/konflux-ci/cli-manifests/release-payloads/prod-release-0.7.16-fbc.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-12-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-12
+  snapshot: fbc-ocp4-12-20260715-132220-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.12
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-13-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-13
+  snapshot: fbc-ocp4-13-20260715-131822-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.13
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-14-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-14
+  snapshot: fbc-ocp4-14-20260715-133110-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.14
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-15-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-15
+  snapshot: fbc-ocp4-15-20260715-132856-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.15
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-16-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-16
+  snapshot: fbc-ocp4-16-20260715-132753-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.16
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-17-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-17
+  snapshot: fbc-ocp4-17-20260715-132124-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.17
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-18-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-18
+  snapshot: fbc-ocp4-18-20260715-131803-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.18
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-19-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-19
+  snapshot: fbc-ocp4-19-20260715-132232-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.19
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-20-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-20
+  snapshot: fbc-ocp4-20-20260715-131925-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.20
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-21-v0-7-16rc1-2026-07-15
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-21
+  snapshot: fbc-ocp4-21-20260715-132105-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.21
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.16
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []

--- a/konflux-ci/cli-manifests/release-payloads/prod-release-0.7.16-managed-clusters.yaml
+++ b/konflux-ci/cli-manifests/release-payloads/prod-release-0.7.16-managed-clusters.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-v0-7-16-managed-clusters-rc1-2026-07-14
+  namespace: dvo-obsint-tenant
+spec:
+ releasePlan: release-plan-managed-clusters-operator
+ snapshot: prod-snapshot-v0-7-16-managed-clusters-rc1-2026-07-14
+ data:
+  releaseNotes:
+    topic: Deployment Validation Operator 0.7.16
+    synopsis: Maintenance update
+    description: |
+      This release resolves issues with outdated libraries and vulnerabilities present in the 0.7.15 release.
+    solution: |
+      Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+    references: []

--- a/konflux-ci/cli-manifests/release-payloads/prod-release-0.7.16-operator.yaml
+++ b/konflux-ci/cli-manifests/release-payloads/prod-release-0.7.16-operator.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-v0-7-16-rc1-2026-07-14
+  namespace: dvo-obsint-tenant
+spec:
+ releasePlan: release-plan-prod
+ snapshot: deployment-validation-operator-20260714-124113-000
+ data:
+  releaseNotes:
+    topic: Deployment Validation Operator 0.7.16
+    synopsis: Maintenance update
+    description: |
+      This release resolves issues with outdated libraries and vulnerabilities present in the 0.7.15 release.
+    solution: |
+      Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+    references: []

--- a/konflux-ci/cli-manifests/release-payloads/prod-release-0.7.17-fbc.yaml
+++ b/konflux-ci/cli-manifests/release-payloads/prod-release-0.7.17-fbc.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-12-v0-7-17rc1-2026-08-25
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-12
+  snapshot: fbc-ocp4-12-20260825-124207-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.12
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.17
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-14-v0-7-17rc1-2026-08-25
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-14
+  snapshot: fbc-ocp4-14-20260825-124215-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.14
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.17
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-16-v0-7-17rc1-2026-08-25
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-16
+  snapshot: fbc-ocp4-16-20260825-124207-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.16
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.17
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-18-v0-7-17rc1-2026-08-25
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-18
+  snapshot: fbc-ocp4-18-20260825-124212-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.18
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.17
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-19-v0-7-17rc1-2026-08-25
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-19
+  snapshot: fbc-ocp4-19-20260825-124213-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.19
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.17
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-20-v0-7-17rc1-2026-08-25
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-20
+  snapshot: fbc-ocp4-20-20260825-150140-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.20
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.17
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: prod-release-fbc-4-21-v0-7-17rc1-2026-08-25
+  namespace: dvo-obsint-tenant
+spec:
+  releasePlan: release-plan-fbc-prod-4-21
+  snapshot: fbc-ocp4-21-20260825-124214-000
+  data:
+    releaseNotes:
+      topic: Deployment Validation Operator FBC for OpenShift v4.21
+      synopsis: FBC update
+      description: |
+        This release includes catalog fragments until DVO 0.7.17
+      solution: |
+        Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+      references: []
+# This release was triggered manually
+#
+# ---
+# apiVersion: appstudio.redhat.com/v1alpha1
+# kind: Release
+# metadata:
+#   name: prod-release-fbc-4-22-v0-7-17rc1-2026-08-25
+#   namespace: dvo-obsint-tenant
+# spec:
+#   releasePlan: release-plan-fbc-prod-4-22
+#   snapshot: 
+#   data:
+#     releaseNotes:
+#       topic: Deployment Validation Operator FBC for OpenShift v4.22
+#       synopsis: FBC update
+#       description: |
+#         This release includes catalog fragments until DVO 0.7.17
+#       solution: |
+#         Before applying this update, make sure all previously released errata relevant to your system have been applied. For details on how to apply this update, refer to: https://access.redhat.com/articles/11258
+#       references: []


### PR DESCRIPTION
#### summary

Added the release payloads for the FBCs on 0.7.17
Also, added missing release payloads for 0.7.16

#### misc

Some of the releases were done using the UI and there is no manifest for them. The UX is now allowing for triggering the snapshots directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production release definitions for Deployment Validation Operator versions 0.7.16 and 0.7.17.
  * Added corresponding managed-clusters operator release definition for version 0.7.16.
  * Included release coverage across supported OpenShift 4.12–4.21 environments.
* **Documentation**
  * Added standardized maintenance and version-specific release notes to production release records.
  * Included release planning and snapshot information to support consistent deployment promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->